### PR TITLE
order 字段名添加分隔符

### DIFF
--- a/application/index/model/CronHandler.php
+++ b/application/index/model/CronHandler.php
@@ -17,7 +17,7 @@ class CronHandler extends Model{
 	public $notifiedUid = [];
 
 	public function __construct(){
-		$this->cornTasks = Db::name('corn')->where('enable',1)->order('rank desc')->select();
+		$this->cornTasks = Db::name('corn')->where('enable',1)->order('`rank` desc')->select();
 		$this->timeNow = time();
 	}
 


### PR DESCRIPTION
order方法中的字段名 rank 不会自动添加 `` ,导致在某些MySQL版本中会报错

![snipaste_2018-11-02_11-09-02](https://user-images.githubusercontent.com/9927289/47891917-290a5500-de90-11e8-88fc-cc4b46bbd5e6.png)
