### PR TITLE
Feat: webdav 适配 rclone

### DIFF
--- a/pkg/webdav/webdav.go
+++ b/pkg/webdav/webdav.go
@@ -400,6 +400,11 @@ func (h *Handler) handleMkcol(w http.ResponseWriter, r *http.Request, fs *filesy
 	if r.ContentLength > 0 {
 		return http.StatusUnsupportedMediaType, nil
 	}
+	if strings.Contains(r.UserAgent(), "rclone") {
+		if _, ok := ctx.Value(fsctx.IgnoreConflictCtx).(bool); !ok {
+			ctx = context.WithValue(ctx, fsctx.IgnoreConflictCtx, true)
+		}
+	}
 	if _, err := fs.CreateDirectory(ctx, reqPath); err != nil {
 		return http.StatusConflict, err
 	}


### PR DESCRIPTION
rclone在传输时会反复创建父目录, 导致cloudreve返回409, 最终导致传输失败.
因此检测如果是rclone则忽略文目录已存在错误