### PR TITLE
Feat: ICP 备案信息

### DIFF
--- a/models/migration.go
+++ b/models/migration.go
@@ -76,6 +76,7 @@ func addDefaultSettings() {
 	defaultSettings := []Setting{
 		{Name: "siteURL", Value: `http://localhost`, Type: "basic"},
 		{Name: "siteName", Value: `Cloudreve`, Type: "basic"},
+		{Name: "siteICPId", Value: ``, Type: "basic"},
 		{Name: "register_enabled", Value: `1`, Type: "register"},
 		{Name: "default_group", Value: `2`, Type: "register"},
 		{Name: "siteKeywords", Value: `网盘，网盘`, Type: "basic"},

--- a/pkg/serializer/setting.go
+++ b/pkg/serializer/setting.go
@@ -5,6 +5,7 @@ import model "github.com/HFO4/cloudreve/models"
 // SiteConfig 站点全局设置序列
 type SiteConfig struct {
 	SiteName           string `json:"title"`
+	SiteICPId          string `json:"siteICPId"`
 	LoginCaptcha       bool   `json:"loginCaptcha"`
 	RegCaptcha         bool   `json:"regCaptcha"`
 	ForgetCaptcha      bool   `json:"forgetCaptcha"`
@@ -64,6 +65,7 @@ func BuildSiteConfig(settings map[string]string, user *model.User) Response {
 	res := Response{
 		Data: SiteConfig{
 			SiteName:           checkSettingValue(settings, "siteName"),
+			SiteICPId:          checkSettingValue(settings, "siteICPId"),
 			LoginCaptcha:       model.IsTrueVal(checkSettingValue(settings, "login_captcha")),
 			RegCaptcha:         model.IsTrueVal(checkSettingValue(settings, "reg_captcha")),
 			ForgetCaptcha:      model.IsTrueVal(checkSettingValue(settings, "forget_captcha")),

--- a/routers/controllers/site.go
+++ b/routers/controllers/site.go
@@ -13,6 +13,7 @@ import (
 func SiteConfig(c *gin.Context) {
 	siteConfig := model.GetSettingByNames(
 		"siteName",
+		"siteICPId",
 		"login_captcha",
 		"reg_captcha",
 		"email_active",


### PR DESCRIPTION
网盘部署在国内需要备案，备案后需在网站显示备案号

设置计划放在基本信息下面
![image](https://user-images.githubusercontent.com/7813681/80784266-47a6e600-8b31-11ea-9562-0aa631162e44.png)

但是想不好备案号放哪里。因为很多地方都是用css `position: fixed` 装饰，比如那个➕。所以很难插在底部因为会遮挡其他组件。
