### PR TITLE
增加 Unix Socket（Unix 套接字）

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,16 @@ func main() {
 		}()
 	}
 
+	// 如果启用了Unix
+	if conf.UnixConfig.Listen != "" {
+		go func() {
+			util.Log().Info("开始监听 %s", conf.UnixConfig.Listen)
+			if err := api.RunUnix(conf.UnixConfig.Listen); err != nil {
+				util.Log().Error("无法监听[%s]，%s", conf.UnixConfig.Listen, err)
+			}
+		}()
+	}
+
 	util.Log().Info("开始监听 %s", conf.SystemConfig.Listen)
 	if err := api.Run(conf.SystemConfig.Listen); err != nil {
 		util.Log().Error("无法监听[%s]，%s", conf.SystemConfig.Listen, err)

--- a/middleware/session.go
+++ b/middleware/session.go
@@ -18,7 +18,7 @@ func Session(secret string) gin.HandlerFunc {
 	// Redis设置不为空，且非测试模式时使用Redis
 	if conf.RedisConfig.Server != "" && gin.Mode() != gin.TestMode {
 		var err error
-		Store, err = redis.NewStoreWithDB(10, "tcp", conf.RedisConfig.Server, conf.RedisConfig.Password, conf.RedisConfig.DB, []byte(secret))
+		Store, err = redis.NewStoreWithDB(10, conf.RedisConfig.Network, conf.RedisConfig.Server, conf.RedisConfig.Password, conf.RedisConfig.DB, []byte(secret))
 		if err != nil {
 			util.Log().Panic("无法连接到 Redis：%s", err)
 		}

--- a/pkg/cache/driver.go
+++ b/pkg/cache/driver.go
@@ -15,7 +15,7 @@ func Init() {
 	if conf.RedisConfig.Server != "" && gin.Mode() != gin.TestMode {
 		Store = NewRedisStore(
 			10,
-			"tcp",
+			conf.RedisConfig.Network,
 			conf.RedisConfig.Server,
 			conf.RedisConfig.Password,
 			conf.RedisConfig.DB,

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -33,6 +33,10 @@ type ssl struct {
 	Listen   string `validate:"required"`
 }
 
+type unix struct {
+    Listen string
+}
+
 // slave 作为slave存储端配置
 type slave struct {
 	Secret          string `validate:"omitempty,gte=64"`
@@ -121,6 +125,7 @@ func Init(path string) {
 		"Database":  DatabaseConfig,
 		"System":    SystemConfig,
 		"SSL":       SSLConfig,
+		"Unix":      UnixConfig,
 		"Captcha":   CaptchaConfig,
 		"Redis":     RedisConfig,
 		"Thumbnail": ThumbConfig,

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -57,6 +57,7 @@ type captcha struct {
 
 // redis 配置
 type redis struct {
+	Network  string
 	Server   string
 	Password string
 	DB       string

--- a/pkg/conf/defaults.go
+++ b/pkg/conf/defaults.go
@@ -66,3 +66,7 @@ var SSLConfig = &ssl{
 	CertPath: "",
 	KeyPath:  "",
 }
+
+var UnixConfig = &unix{
+    Listen: "",
+}

--- a/pkg/conf/defaults.go
+++ b/pkg/conf/defaults.go
@@ -4,6 +4,7 @@ import "github.com/mojocn/base64Captcha"
 
 // RedisConfig Redis服务器配置
 var RedisConfig = &redis{
+	Network:  "tcp",
 	Server:   "",
 	Password: "",
 	DB:       "0",


### PR DESCRIPTION
### **配置文件请勿直接套用，根据自身配置进行改动**

> 暂未添加Mysql，使用`localhost`地址Mysql会自动转换成`unix`进行连接

### Nginx 配置文件（二选一）
> 配置方法（一）
```
http
{
    upstream cloudreve {
        server unix:/run/cloudreve/cloudreve.sock;
    }
    server {
        location / {
            proxy_pass http://cloudreve;
        }
    }
}
```

> 配置方法（二）
```
http
{
    server {
        location / {
            proxy_pass http://unix:/run/cloudreve/cloudreve.sock;
        }
    }
}
```

### Cloudreve 配置文件
```
; Unix 相关
[Unix]
Listen = /run/cloudreve/cloudreve.sock

; Redis 相关
[Redis]
; Reids 连接方式，支持 tcp | udp | unix
; 默认 tcp
Network = unix
Server = /run/redis/redis.sock
Password =
DB = 0
```
