### PR TITLE
Force utf8 encoding on migration

### DIFF
--- a/models/migration.go
+++ b/models/migration.go
@@ -32,7 +32,7 @@ func migration() {
 
 	// 自动迁移模式
 	if conf.DatabaseConfig.Type == "mysql" {
-		DB = DB.Set("gorm:table_options", "ENGINE=InnoDB")
+		DB = DB.Set("gorm:table_options", "ENGINE=InnoDB CHARSET=utf8")
 	}
 	DB.AutoMigrate(&User{}, &Setting{}, &Group{}, &Policy{}, &Folder{}, &File{}, &Share{},
 		&Task{}, &Download{}, &Tag{}, &Webdav{})


### PR DESCRIPTION
Force table coding to utf8 to avoid index too long error