### PR TITLE
Fix: 阿里云的 golang SDK 会把整个 object KEY也编码

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ version.lock
 *.ini
 conf/conf.ini
 /statik/
+/vendor/


### PR DESCRIPTION
(cherry picked from commit b9cd82b849065f0d1ad093708f09c8722339bf2a)

Fix https://github.com/cloudreve/Cloudreve/issues/677