### PR TITLE
Fix: email address should be lowercase for requesting Gravatar

### DIFF
--- a/service/user/setting.go
+++ b/service/user/setting.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	model "github.com/cloudreve/Cloudreve/v3/models"
 	"github.com/cloudreve/Cloudreve/v3/pkg/serializer"
@@ -200,8 +201,8 @@ func (service *AvatarService) Get(c *gin.Context) serializer.Response {
 		if err != nil {
 			return serializer.Err(serializer.CodeInternalSetting, "无法解析 Gravatar 服务器地址", err)
 		}
-
-		has := md5.Sum([]byte(user.Email))
+		email_lowered := strings.ToLower(user.Email)
+		has := md5.Sum([]byte(email_lowered))
 		avatar, _ := url.Parse(fmt.Sprintf("/avatar/%x?d=mm&s=%s", has, sizes[service.Size]))
 
 		return serializer.Response{


### PR DESCRIPTION
## Change(s) in this PR

Use the lowercased email address to create a request to Gravatar.

According to [Gravatar](https://en.gravatar.com/site/implement/hash/), the email address should be lowercase to create a consistent hash.  
There is a chance that a user registered with an email address containing uppercase characters. This can lead to a bug, that users will never get their avatar from Gravatar.