### PR TITLE
注册帐号时，如果尚未验证，再发一次验证信

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -90,7 +90,7 @@ func WebDAVAuth() gin.HandlerFunc {
 			return
 		}
 
-		expectedUser, err := model.GetUserByEmail(username)
+		expectedUser, err := model.GetActiveUserByEmail(username)
 		if err != nil {
 			c.Status(http.StatusUnauthorized)
 			c.Abort()

--- a/models/user.go
+++ b/models/user.go
@@ -140,7 +140,7 @@ func GetActiveUserByOpenID(openid string) (User, error) {
 // GetUserByEmail 用Email获取用户
 func GetUserByEmail(email string) (User, error) {
 	var user User
-	result := DB.Set("gorm:auto_preload", true).Where("status = ? and email = ?", Active, email).First(&user)
+	result := DB.Set("gorm:auto_preload", true).Where("email = ?", email).First(&user)
 	return user, result.Error
 }
 

--- a/models/user.go
+++ b/models/user.go
@@ -144,6 +144,13 @@ func GetUserByEmail(email string) (User, error) {
 	return user, result.Error
 }
 
+// GetActiveUserByEmail 用Email获取可登录用户
+func GetActiveUserByEmail(email string) (User, error) {
+	var user User
+	result := DB.Set("gorm:auto_preload", true).Where("status = ? and email = ?", Active, email).First(&user)
+	return user, result.Error
+}
+
 // NewUser 返回一个新的空 User
 func NewUser() User {
 	options := UserOption{}

--- a/routers/controllers/user.go
+++ b/routers/controllers/user.go
@@ -18,7 +18,7 @@ import (
 // StartLoginAuthn 开始注册WebAuthn登录
 func StartLoginAuthn(c *gin.Context) {
 	userName := c.Param("username")
-	expectedUser, err := model.GetUserByEmail(userName)
+	expectedUser, err := model.GetActiveUserByEmail(userName)
 	if err != nil {
 		c.JSON(200, serializer.Err(serializer.CodeNotFound, "用户不存在", err))
 		return
@@ -52,7 +52,7 @@ func StartLoginAuthn(c *gin.Context) {
 // FinishLoginAuthn 完成注册WebAuthn登录
 func FinishLoginAuthn(c *gin.Context) {
 	userName := c.Param("username")
-	expectedUser, err := model.GetUserByEmail(userName)
+	expectedUser, err := model.GetActiveUserByEmail(userName)
 	if err != nil {
 		c.JSON(200, serializer.Err(serializer.CodeCredentialInvalid, "用户邮箱或密码错误", err))
 		return

--- a/service/user/login.go
+++ b/service/user/login.go
@@ -94,6 +94,12 @@ func (service *UserResetEmailService) Reset(c *gin.Context) serializer.Response 
 	// 查找用户
 	if user, err := model.GetUserByEmail(service.UserName); err == nil {
 
+		if user.Status == model.Baned || user.Status == model.OveruseBaned {
+			return serializer.Err(403, "该账号已被封禁", nil)
+		}
+		if user.Status == model.NotActivicated {
+			return serializer.Err(403, "该账号未激活", nil)
+		}
 		// 创建密码重设会话
 		secret := util.RandStringRunes(32)
 		cache.Set(fmt.Sprintf("user_reset_%d", user.ID), secret, 3600)

--- a/service/user/login.go
+++ b/service/user/login.go
@@ -62,7 +62,10 @@ func (service *UserResetService) Reset(c *gin.Context) serializer.Response {
 	if err := user.Update(map[string]interface{}{"password": user.Password}); err != nil {
 		return serializer.DBErr("无法重设密码", err)
 	}
-
+	// 重设二步验证设定
+	if err := user.Update(map[string]interface{}{"two_factor": ""}); err != nil {
+		return serializer.DBErr("无法更新二步验证设定", err)
+	}
 	cache.Deletes([]string{fmt.Sprintf("%d", uid)}, "user_reset_")
 	return serializer.Response{}
 }

--- a/service/user/login.go
+++ b/service/user/login.go
@@ -62,10 +62,7 @@ func (service *UserResetService) Reset(c *gin.Context) serializer.Response {
 	if err := user.Update(map[string]interface{}{"password": user.Password}); err != nil {
 		return serializer.DBErr("无法重设密码", err)
 	}
-	// 重设二步验证设定
-	if err := user.Update(map[string]interface{}{"two_factor": ""}); err != nil {
-		return serializer.DBErr("无法更新二步验证设定", err)
-	}
+
 	cache.Deletes([]string{fmt.Sprintf("%d", uid)}, "user_reset_")
 	return serializer.Response{}
 }

--- a/service/user/register.go
+++ b/service/user/register.go
@@ -109,7 +109,7 @@ func (service *UserRegisterService) Register(c *gin.Context) serializer.Response
 		}
 		if userNotActivated == true {
 			//原本在上面要抛出的DBErr，放来这边抛出
-			return serializer.DBErr("用户未激活，已重新发送激活码", nil)
+			return serializer.DBErr("用户未激活，已重新发送激活邮件", nil)
 		} else {
 			return serializer.Response{Code: 203}
 		}

--- a/service/user/register.go
+++ b/service/user/register.go
@@ -64,10 +64,16 @@ func (service *UserRegisterService) Register(c *gin.Context) serializer.Response
 		user.Status = model.NotActivicated
 	}
 	user.GroupID = uint(defaultGroup)
-
+	userNotActivated := false
 	// 创建用户
 	if err := model.DB.Create(&user).Error; err != nil {
-		return serializer.DBErr("此邮箱已被使用", err)
+		//检查已存在使用者是否尚未激活
+		expectedUser, err := model.GetUserByEmail(service.UserName)
+		if expectedUser.Status == model.NotActivicated {
+			userNotActivated = true
+		} else {
+			return serializer.DBErr("此邮箱已被使用", err)
+		}
 	}
 
 	// 发送激活邮件
@@ -100,8 +106,12 @@ func (service *UserRegisterService) Register(c *gin.Context) serializer.Response
 		if err := email.Send(user.Email, title, body); err != nil {
 			return serializer.Err(serializer.CodeInternalSetting, "无法发送激活邮件", err)
 		}
-
-		return serializer.Response{Code: 203}
+		if userNotActivated == true {
+			//原本在上面要抛出的DBErr，放来这边抛出
+			return serializer.DBErr("用户未激活，已重新发送激活码", nil)
+		} else {
+			return serializer.Response{Code: 203}
+		}
 	}
 
 	return serializer.Response{}

--- a/service/user/register.go
+++ b/service/user/register.go
@@ -71,6 +71,7 @@ func (service *UserRegisterService) Register(c *gin.Context) serializer.Response
 		expectedUser, err := model.GetUserByEmail(service.UserName)
 		if expectedUser.Status == model.NotActivicated {
 			userNotActivated = true
+			user = expectedUser
 		} else {
 			return serializer.DBErr("此邮箱已被使用", err)
 		}


### PR DESCRIPTION
1. 未验证显示密码错误
    1. ```GetUserByEmail```看语意是根据email取得user
    2. 但是 sql 语句却只select已激活user
    3. 导致login.go 拿不到正确的user资讯
    4. 永远只会提示密码错误
2. 注册帐号时，如果尚未验证，再发一次验证信
    1. 因为我这边也是用```GetUserByEmail```拿取user资讯，但是一直拿不到资讯，顺便发现了上面的bug
    2. 现在改成如果已存在的使用者未激活，会这样提示
    3. ![image](https://user-images.githubusercontent.com/73118488/108261924-3651c780-719f-11eb-83b7-2407e8e22532.png)
    3. 并且再发送一次验证码