### PR TITLE
建议：支持utf8mb4的cloudreve添加

### DIFF
--- a/models/init.go
+++ b/models/init.go
@@ -37,7 +37,7 @@ func Init() {
 			// 当前只支持 sqlite3 与 mysql 数据库
 			// TODO: import 其他 gorm 支持的主流数据库？否则直接 Open 没有任何意义。
 			// TODO: 数据库连接其他参数允许用户自定义？譬如编码更换为 utf8mb4 以支持表情。
-			db, err = gorm.Open("mysql", fmt.Sprintf("%s:%s@(%s:%d)/%s?charset=utf8&parseTime=True&loc=Local",
+			db, err = gorm.Open("mysql", fmt.Sprintf("%s:%s@(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local",
 				conf.DatabaseConfig.User,
 				conf.DatabaseConfig.Password,
 				conf.DatabaseConfig.Host,


### PR DESCRIPTION
可以制作两个版本，分别对应utf8与utf8mb4以支持在昵称中添加表情，或支持QQ登陆时在获取到有表情的昵称时不出现报错。