### PR TITLE
delete $name policy condition

### DIFF
--- a/pkg/filesystem/driver/s3/handler.go
+++ b/pkg/filesystem/driver/s3/handler.go
@@ -344,7 +344,6 @@ func (handler Driver) Token(ctx context.Context, TTL int64, key string) (seriali
 			map[string]string{"bucket": handler.Policy.BucketName},
 			[]string{"starts-with", "$key", savePath},
 			[]string{"starts-with", "$success_action_redirect", apiURL.String()},
-			[]string{"starts-with", "$name", ""},
 			[]string{"starts-with", "$Content-Type", ""},
 			map[string]string{"x-amz-algorithm": "AWS4-HMAC-SHA256"},
 		},


### PR DESCRIPTION
"name" is not in the list of supported conditions for policies: [supported conditions](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html#sigv4-PolicyConditions)
With the current configuration, AWS S3 returns the same error as Scaleway Object Storage.

Details: #824 