### PR TITLE
fix webdav prop get

### DIFF
--- a/pkg/webdav/prop.go
+++ b/pkg/webdav/prop.go
@@ -188,7 +188,7 @@ func props(ctx context.Context, fs *filesystem.FileSystem, ls LockSystem, fi Fil
 		}
 		// Otherwise, it must either be a live property or we don't know it.
 		if prop := liveProps[pn]; prop.findFn != nil && (prop.dir || !isDir) {
-			innerXML, err := prop.findFn(ctx, fs, ls, "", fi)
+			innerXML, err := prop.findFn(ctx, fs, ls, fi.GetName(), fi)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
修复了displayname为空，potplayer可以正常使用webdav功能