### PR TITLE
相对路径切换为相对工作目录而不是可执行文件

### DIFF
--- a/global/conf.go
+++ b/global/conf.go
@@ -1,3 +1,3 @@
 package global
 
-var conf map[string]interface{}
+var Conf map[string]interface{}

--- a/global/conf.go
+++ b/global/conf.go
@@ -1,0 +1,3 @@
+package global
+
+var conf map[string]interface{}

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&confPath, "c", util.RelativePath("conf.ini"), "配置文件路径")
+	flag.StringVar(&confPath, "c", util.RelativeExecutablePath("conf.ini"), "配置文件路径")
 	flag.BoolVar(&isEject, "eject", false, "导出内置静态资源")
 	flag.StringVar(&scriptName, "database-script", "", "运行内置数据库助手脚本")
 	flag.Parse()

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -26,6 +26,7 @@ type system struct {
 	Debug         bool
 	SessionSecret string
 	HashIDSalt    string
+	DataPath  string
 }
 
 type ssl struct {

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -149,7 +149,7 @@ func Init(path string) {
 		util.Log()
 	}
 
-	global.conf := sections
+	global.Conf := sections
 }
 
 // mapSection 将配置文件的 Section 映射到结构体上

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"github.com/cloudreve/Cloudreve/v3/pkg/util"
+	"github.com/cloudreve/Cloudreve/v3/global"
 	"github.com/go-ini/ini"
 	"gopkg.in/go-playground/validator.v9"
 )
@@ -148,6 +149,7 @@ func Init(path string) {
 		util.Log()
 	}
 
+	global.conf := sections
 }
 
 // mapSection 将配置文件的 Section 映射到结构体上

--- a/pkg/util/path.go
+++ b/pkg/util/path.go
@@ -48,11 +48,23 @@ func FormSlash(old string) string {
 	return path.Clean(strings.ReplaceAll(old, "\\", "/"))
 }
 
-// RelativePath 获取相对工作目录的路径
+// RelativeExecutablePath 获取相对可执行文件的路径
+func RelativeExecutablePath(name string) string {
+	if filepath.IsAbs(name) {
+		return name
+	}
+	e, _ := os.Executable()
+	return filepath.Join(filepath.Dir(e), name)
+}
+
+//RelativePath 获取相对路径
 func RelativePath(name string) string {
 	if filepath.IsAbs(name) {
 		return name
 	}
-	e, _ := os.Getwd()
-	return filepath.Join(e, name)
+	if conf.SystemConfig.DataPath != "" {
+		return filepath.Join(conf.SystemConfig.DataPath, name)
+	} else {
+		return RelativeExecutablePath(name)
+	}
 }

--- a/pkg/util/path.go
+++ b/pkg/util/path.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"github.com/cloudreve/Cloudreve/v3/pkg/conf"
+	"github.com/cloudreve/Cloudreve/v3/global"
 )
 
 // DotPathToStandardPath 将","分割的路径转换为标准路径
@@ -63,8 +63,9 @@ func RelativePath(name string) string {
 	if filepath.IsAbs(name) {
 		return name
 	}
-	if conf.SystemConfig.DataPath != "" {
-		return filepath.Join(conf.SystemConfig.DataPath, name)
+	SystemConfig, ok := global.conf[ "SystemConfig" ]
+	if SystemConfig.DataPath != "" {
+		return filepath.Join(SystemConfig.DataPath, name)
 	} else {
 		return RelativeExecutablePath(name)
 	}

--- a/pkg/util/path.go
+++ b/pkg/util/path.go
@@ -48,11 +48,11 @@ func FormSlash(old string) string {
 	return path.Clean(strings.ReplaceAll(old, "\\", "/"))
 }
 
-// RelativePath 获取相对可执行文件的路径
+// RelativePath 获取相对工作目录的路径
 func RelativePath(name string) string {
 	if filepath.IsAbs(name) {
 		return name
 	}
-	e, _ := os.Executable()
-	return filepath.Join(filepath.Dir(e), name)
+	e, _ := os.Getwd()
+	return filepath.Join(e, name)
 }

--- a/pkg/util/path.go
+++ b/pkg/util/path.go
@@ -63,7 +63,7 @@ func RelativePath(name string) string {
 	if filepath.IsAbs(name) {
 		return name
 	}
-	SystemConfig, ok := global.conf[ "SystemConfig" ]
+	SystemConfig, ok := global.Conf[ "SystemConfig" ]
 	if SystemConfig.DataPath != "" {
 		return filepath.Join(SystemConfig.DataPath, name)
 	} else {

--- a/pkg/util/path.go
+++ b/pkg/util/path.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"github.com/cloudreve/Cloudreve/v3/pkg/conf"
 )
 
 // DotPathToStandardPath 将","分割的路径转换为标准路径


### PR DESCRIPTION
我一直在使用Cloudreve作为文件分享工具，极简的设计思路非常吸引我，下载、运行、浏览器登录，一切搞定。

近期我在尝试把Cloudreve容器化，发现一个可以改进的地方。

Cloudreve的配置文件中，没有提供修改文件存储位置的选项，直接把文件存储到可执行文件所在的目录。

当我把Cloudreve放置在容器中时，这会导致数据库文件被存储在容器层中（uploads文件夹我可以挂载成其他卷，从而避免文件被写入容器层）。

由于我是部署在K8S上，每当容器重启时，容器层中的数据都会丢失。

是否可以考虑使用当前工作目录而不是可执行文件所在的目录存放文件呢？

这样容器中的Cloudreve，只需要cd到挂载的持久卷中，就可以把所有需要持久化的数据永久保存，无惧容器重启。