### PR TITLE
Remove unnecessary import "C"

### DIFF
--- a/routers/controllers/file.go
+++ b/routers/controllers/file.go
@@ -1,6 +1,5 @@
 package controllers
 
-import "C"
 import (
 	"context"
 	"fmt"


### PR DESCRIPTION
There are no C binding in this file. And for users to compile themselves, this line will cause compilation to fail for those who don't need sqlite support.

移除不必要的c binding，使用CGO=0时，这行会导致编译失败。禁用CGO会导致sqlite无法使用，但可以方便编译（不需要安装gcc，跨平台编译方便），这点可以在文档中说明。