### PR TITLE
Integrate aria2c support & fix unintended behavior for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,13 +46,17 @@ ARG TZ="Asia/Shanghai"
 ENV TZ ${TZ}
 
 COPY --from=be-builder /go/bin/Cloudreve /cloudreve/cloudreve
+COPY docker-bootstrap.sh /cloudreve/bootstrap.sh
 
 RUN apk upgrade \
-    && apk add bash tzdata \
+    && apk add bash tzdata aria2 \
     && ln -s /cloudreve/cloudreve /usr/bin/cloudreve \
     && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo ${TZ} > /etc/timezone \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    && mkdir /etc/cloudreve \
+    && ln -s /etc/cloudreve/cloureve.db /cloudreve/cloudreve.db \
+    && ln -s /etc/cloudreve/conf.ini /cloudreve/conf.ini
 
 # cloudreve use tcp 5212 port by default
 EXPOSE 5212/tcp
@@ -65,4 +69,4 @@ VOLUME /etc/cloudreve
 
 VOLUME /data
 
-ENTRYPOINT ["cloudreve"]
+ENTRYPOINT ["sh", "/cloudreve/bootstrap.sh"]

--- a/docker-bootstrap.sh
+++ b/docker-bootstrap.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+GREEN='\033[0;32m'
+RESET='\033[0m'
+if [ ! -f /etc/cloudreve/aria2c.conf ]; then
+    echo -e "[${GREEN}aria2c${RESET}] aria2c config not found. Generating..."
+    secret=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13)
+    echo -e "[${GREEN}aria2c${RESET}] Generated port: 6800, secret: $secret"
+    cat <<EOF > /etc/cloudreve/aria2c.conf
+enable-rpc=true
+rpc-listen-port=6800
+rpc-secret=$secret
+EOF
+fi
+aria2c --conf-path /etc/cloudreve/aria2c.conf -D
+cloudreve


### PR DESCRIPTION
This PR generally did 2 things:
1. Fix unintended behavior for docker image
In Dockerfile it claims that user can specify their own config file in /etc/cloudreve but in face cloudreve would never read config from this file as cloudreve always reads config file from the same folder where cloudreve binary lives except explicit config path are specified. Thus this pr fixes this problem.
Dockerfile 里说可以把配置文件丢  /etc/cloudreve 这样用户也可以把这个目录映射到主机上，但实际上 cloudreve 压根不会读取这个目录下的东西所以做了个小修改

2. Integrate aria2c support
There's no vanilla support for aria2c in the docker image so I made one. It would generate aria2c password and print it in the log during first startup so that user can paste the password in the control panel and it now works.
在 Docker 镜像里集成了 aria2c，首次启动的时候会生成密码并输出到终端，用户可以直接在面板里输入密码就能启用离线下载