### PR TITLE
Fix: trigger err when move folder into itself

### DIFF
--- a/models/folder.go
+++ b/models/folder.go
@@ -263,6 +263,13 @@ func (folder *Folder) CopyFolderTo(folderID uint, dstFolder *Folder) (size uint6
 // MoveFolderTo 将folder目录下的dirs子目录复制或移动到dstFolder，
 // 返回此过程中增加的容量
 func (folder *Folder) MoveFolderTo(dirs []uint, dstFolder *Folder) error {
+
+	// 如果目标位置为待移动的目录，会导致 parent 为自己
+	// 造成死循环且无法被除搜索以外的组件展示
+	if folder.OwnerID == dstFolder.OwnerID && util.ContainsUint(dirs, dstFolder.ID) {
+		return errors.New("cannot move a folder into itself")
+	}
+
 	// 更改顶级要移动目录的父目录指向
 	err := DB.Model(Folder{}).Where(
 		"id in (?) and owner_id = ? and parent_id = ?",

--- a/models/folder_test.go
+++ b/models/folder_test.go
@@ -493,7 +493,8 @@ func TestFolder_MoveOrCopyFolderTo_Move(t *testing.T) {
 	}
 	// 目标目录
 	dstFolder := Folder{
-		Model: gorm.Model{ID: 10},
+		Model:   gorm.Model{ID: 10},
+		OwnerID: 1,
 	}
 
 	// 成功
@@ -506,6 +507,12 @@ func TestFolder_MoveOrCopyFolderTo_Move(t *testing.T) {
 		err := parFolder.MoveFolderTo([]uint{1, 2}, &dstFolder)
 		asserts.NoError(mock.ExpectationsWereMet())
 		asserts.NoError(err)
+	}
+
+	// 移动自己到自己内部，失败
+	{
+		err := parFolder.MoveFolderTo([]uint{10, 2}, &dstFolder)
+		asserts.Error(err)
 	}
 }
 


### PR DESCRIPTION
when the id of destination folder inside the id set of moved folder, will cause an error that the parent of this folder will be itself, not an really error since the frontend forbidden this move action, but still an issue in some specific scenarios.