### PR TITLE
fix: 七牛云与又拍云存储读取时发生 nil pointer dereference

### DIFF
--- a/pkg/filesystem/driver/qiniu/handler.go
+++ b/pkg/filesystem/driver/qiniu/handler.go
@@ -118,7 +118,7 @@ func (handler Driver) Get(ctx context.Context, path string) (response.RSCloser, 
 	}
 
 	// 获取文件数据流
-	client := request.HTTPClient{}
+	client := request.NewClient()
 	resp, err := client.Request(
 		"GET",
 		downloadURL,

--- a/pkg/filesystem/driver/upyun/handler.go
+++ b/pkg/filesystem/driver/upyun/handler.go
@@ -119,7 +119,7 @@ func (handler Driver) Get(ctx context.Context, path string) (response.RSCloser, 
 	}
 
 	// 获取文件数据流
-	client := request.HTTPClient{}
+	client := request.NewClient()
 	resp, err := client.Request(
 		"GET",
 		downloadURL,


### PR DESCRIPTION
本 PR 修正了七牛云、又拍云 Get 方法的问题，该问题会导致调用方法时发生 `nil pointer dereference`。

该问题会导致包括多文件压缩在内的若干功能无法正常使用。

![Screenshot_20220225_234204](https://user-images.githubusercontent.com/13360135/155758410-23353e48-c774-4410-9376-87f85e031d17.jpg)

