### PR TITLE
feat:support mysql ssl/tls connect

### DIFF
--- a/models/init.go
+++ b/models/init.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cloudreve/Cloudreve/v3/pkg/conf"
@@ -36,12 +37,19 @@ func Init() {
 			// 未指定数据库或者明确指定为 sqlite 时，使用 SQLite3 数据库
 			db, err = gorm.Open("sqlite3", util.RelativePath(conf.DatabaseConfig.DBFile))
 		case "postgres":
-			db, err = gorm.Open(conf.DatabaseConfig.Type, fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%d sslmode=disable",
+			var sslmode = "disable"
+			if strings.EqualFold(conf.DatabaseConfig.TLS, "true") {
+				sslmode = "require"
+			} else {
+				sslmode = "disable"
+			}
+			db, err = gorm.Open(conf.DatabaseConfig.Type, fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%d sslmode=%s",
 				conf.DatabaseConfig.Host,
 				conf.DatabaseConfig.User,
 				conf.DatabaseConfig.Password,
 				conf.DatabaseConfig.Name,
-				conf.DatabaseConfig.Port))
+				conf.DatabaseConfig.Port,
+				sslmode))
 		case "mysql", "mssql":
 			db, err = gorm.Open(conf.DatabaseConfig.Type, fmt.Sprintf("%s:%s@(%s:%d)/%s?charset=%s&parseTime=True&loc=Local&tls=%s",
 				conf.DatabaseConfig.User,

--- a/models/init.go
+++ b/models/init.go
@@ -43,13 +43,14 @@ func Init() {
 				conf.DatabaseConfig.Name,
 				conf.DatabaseConfig.Port))
 		case "mysql", "mssql":
-			db, err = gorm.Open(conf.DatabaseConfig.Type, fmt.Sprintf("%s:%s@(%s:%d)/%s?charset=%s&parseTime=True&loc=Local",
+			db, err = gorm.Open(conf.DatabaseConfig.Type, fmt.Sprintf("%s:%s@(%s:%d)/%s?charset=%s&parseTime=True&loc=Local&tls=%s",
 				conf.DatabaseConfig.User,
 				conf.DatabaseConfig.Password,
 				conf.DatabaseConfig.Host,
 				conf.DatabaseConfig.Port,
 				conf.DatabaseConfig.Name,
-				conf.DatabaseConfig.Charset))
+				conf.DatabaseConfig.Charset,
+				conf.DatabaseConfig.Tls))
 		default:
 			util.Log().Panic("不支持数据库类型: %s", conf.DatabaseConfig.Type)
 		}

--- a/models/init.go
+++ b/models/init.go
@@ -50,7 +50,7 @@ func Init() {
 				conf.DatabaseConfig.Port,
 				conf.DatabaseConfig.Name,
 				conf.DatabaseConfig.Charset,
-				conf.DatabaseConfig.Tls))
+				conf.DatabaseConfig.TLS))
 		default:
 			util.Log().Panic("不支持数据库类型: %s", conf.DatabaseConfig.Type)
 		}

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -17,6 +17,7 @@ type database struct {
 	DBFile      string
 	Port        int
 	Charset     string
+	Tls         string
 }
 
 // system 系统通用配置

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -17,7 +17,7 @@ type database struct {
 	DBFile      string
 	Port        int
 	Charset     string
-	Tls         string
+	TLS         string
 }
 
 // system 系统通用配置


### PR DESCRIPTION
支持了mysql的tls存储 使用方法是在conf.ini中添加一行 Tls = true
```
[Database]
; 数据库类型，目前支持 sqlite/mysql/mssql/postgres
Type = mysql
; MySQL 端口
Port = 3306
; 用户名
User = username
; 密码
Password = password
; 数据库地址
Host = 127.0.0.1
; 数据库名称
Name = cloudreve
; 数据表前缀
TablePrefix = cd_
; 字符集
Charset = utf8
; SQLite 数据库文件路径
DBFile = cloudreve.db
Tls = true
```