### PR TITLE
Update docker image packaging.

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,9 +1,10 @@
 name: Build and push docker image
 
 on:
-  push:
-    tags:
-      - 3.* # triggered on every push with tag 3.*
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
   workflow_dispatch: # or just on button clicked
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,41 @@
-FROM golang:1.17-alpine as cloudreve_builder
+FROM alpine:latest as builder
 
+ARG TARGETARCH
+ARG TARGETVARIANT
 
-# install dependencies and build tools
-RUN apk update && apk add --no-cache wget curl git yarn build-base gcc abuild binutils binutils-doc gcc-doc zip
+ARG ReleaseApi="https://api.github.com/repos/cloudreve/Cloudreve/releases/latest"
 
-WORKDIR /cloudreve_builder
-RUN git clone --recurse-submodules https://github.com/cloudreve/Cloudreve.git
+WORKDIR /ProjectCloudreve
 
-# build frontend
-WORKDIR /cloudreve_builder/Cloudreve/assets
-RUN yarn install --network-timeout 1000000
-RUN yarn run build && find . -name "*.map" -type f -delete
+RUN apk add tar gzip curl sed grep
 
-# build backend
-WORKDIR /cloudreve_builder/Cloudreve
-RUN zip -r - assets/build >assets.zip
-RUN tag_name=$(git describe --tags) \
-    && export COMMIT_SHA=$(git rev-parse --short HEAD) \
-    && go build -a -o cloudreve -ldflags " -X 'github.com/HFO4/cloudreve/pkg/conf.BackendVersion=$tag_name' -X 'github.com/HFO4/cloudreve/pkg/conf.LastCommit=$COMMIT_SHA'"
+RUN echo "${TARGETARCH}<======>${TARGETVARIANT}"
 
+RUN if [ "0$(uname -m)" = "0x86_64" ]; then export Arch="amd64" ;fi \
+    && if [ "0$(uname -m)" = "0arm64" ] || [ "0$(uname -m)" = "0aarch64" ]; then export Arch="arm64" ;fi \
+    && if [ "0$(uname -m)" = "0arm" ] || [ "0$(uname -m)" = "0armv7l" ]; then export Arch="arm" ;fi \
+    && if [ "0$Arch" = "0" ]; then exit 5 ;fi \
+    && targetUrl=$(curl -s "${ReleaseApi}" | sed -e 's/"/\n/g' | grep http | grep linux | grep "${Arch}.tar") \
+    && echo ">>>>>> AssetUrl: ${targetUrl}" \
+    && curl -L --max-redirs 10 -o ./cloudreve.tar.gz "${targetUrl}"
+
+RUN tar xzf ./cloudreve.tar.gz
 
 # build final image
 FROM alpine:latest
 
 WORKDIR /cloudreve
 
-RUN apk update && apk add --no-cache tzdata
+RUN apk update && apk add --no-cache gcompat tzdata
 
 # we using the `Asia/Shanghai` timezone by default, you can do modification at your will
 RUN cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone
 
-COPY --from=cloudreve_builder /cloudreve_builder/Cloudreve/cloudreve ./
+COPY --from=cloudreve_builder /ProjectCloudreve/cloudreve ./
 
-# prepare permissions and aria2 dir
-RUN chmod +x ./cloudreve && mkdir -p /data/aria2 && chmod -R 766 /data/aria2
+# prepare permissions and aria2 dir(directory only)
+RUN chmod +x ./cloudreve && mkdir -p /data/aria2 && chmod /data/aria2
 
 EXPOSE 5212
 VOLUME ["/cloudreve/uploads", "/cloudreve/avatar", "/data"]


### PR DESCRIPTION
[Update Dockerfile](https://github.com/cloudreve/Cloudreve/commit/41232d11b41c952e7ae7ea2e8267b08c9c0dcc7a)
Use released binary file from github rather than build with static flag. this will make docker image's behavior as same as released binary file. and this will take up less image space, take up less runtime memory, save workflow resource.
`使用github上已经发布的二进制文件而不是使用静态链接库标志构建，这可以使docker映像的行为与release的二进制文件保持一致。并且，这将占用更少的镜像空间，占用更少的运行时内存，节省工作流资源。`

[Update docker-release.yml](https://github.com/cloudreve/Cloudreve/commit/d9d87b4b5fb41f4cd291e9c7b7ac67c3ebaca357)
let docker action runs after binary file released completed.
`使docker的构建，在二进制文件发布完成之后。`