### PR TITLE
webdav通过文件扩展名判断content-type

### DIFF
--- a/pkg/webdav/prop.go
+++ b/pkg/webdav/prop.go
@@ -10,7 +10,9 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"mime"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -381,7 +383,7 @@ func findContentType(ctx context.Context, fs *filesystem.FileSystem, ls LockSyst
 	//// Rewind file.
 	//_, err = f.Seek(0, os.SEEK_SET)
 	//return ctype, err
-	return "", nil
+	return mime.TypeByExtension(filepath.Ext(name)), nil
 }
 
 // ETager is an optional interface for the os.FileInfo objects


### PR DESCRIPTION
webdav响应中content-type全部为空，通过文件扩展名进行判断