### PR TITLE
修复unix下日志客户端ip为空，添加配置项设置从哪个header获取

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func main() {
 			}
 		}
 
+		api.TrustedPlatform = conf.UnixConfig.ProxyHeader
 		util.Log().Info("开始监听 %s", conf.UnixConfig.Listen)
 		if err := api.RunUnix(conf.UnixConfig.Listen); err != nil {
 			util.Log().Error("无法监听[%s]，%s", conf.UnixConfig.Listen, err)

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -35,7 +35,8 @@ type ssl struct {
 }
 
 type unix struct {
-	Listen string
+	Listen      string
+	ProxyHeader string `validate:"required_with=Listen"`
 }
 
 // slave 作为slave存储端配置

--- a/pkg/conf/defaults.go
+++ b/pkg/conf/defaults.go
@@ -45,7 +45,8 @@ var SSLConfig = &ssl{
 }
 
 var UnixConfig = &unix{
-	Listen: "",
+	Listen:      "",
+	ProxyHeader: "X-Forwarded-For",
 }
 
 var OptionOverwrite = map[string]interface{}{}


### PR DESCRIPTION
cloudreve监听unix时日志中客户端ip为空，添加选择项从哪个header获取，默认为"X-Forwarded-For"