### PR TITLE
Fix: preview api returns raw filename

### DIFF
--- a/service/explorer/file.go
+++ b/service/explorer/file.go
@@ -354,6 +354,9 @@ func (service *FileIDService) PreviewContent(ctx context.Context, c *gin.Context
 		c.Header("Cache-Control", "no-cache")
 	}
 
+	// 设置文件名
+	c.Header("Content-Disposition", "attachment; filename=\""+url.PathEscape(fs.FileTarget[0].Name)+"\"")
+
 	http.ServeContent(c.Writer, c.Request, fs.FileTarget[0].Name, fs.FileTarget[0].UpdatedAt, resp.Content)
 
 	return serializer.Response{


### PR DESCRIPTION
Add a missing header `Content-Disposition` as [DownloadService.Download](https://github.com/cloudreve/Cloudreve/blob/21d2b817f4b1287ef22b2939bf89292a389affcf/service/explorer/file.go#L290).