### PR TITLE
Fix: admin summary cannot be cached in redis

### DIFF
--- a/service/admin/site.go
+++ b/service/admin/site.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"encoding/gob"
 	"time"
 
 	model "github.com/cloudreve/Cloudreve/v3/models"
@@ -9,6 +10,11 @@ import (
 	"github.com/cloudreve/Cloudreve/v3/pkg/email"
 	"github.com/cloudreve/Cloudreve/v3/pkg/serializer"
 )
+
+func init() {
+	gob.Register(map[string]interface{}{})
+	gob.Register(map[string]string{})
+}
 
 // NoParamService 无需参数的服务
 type NoParamService struct {


### PR DESCRIPTION
Summary in admin dashboard caching was introduced in [0c9383](https://github.com/cloudreve/Cloudreve/commit/0c9383e329542c5dad94f7560190cde04e93f6af).
It calls `cache.Set` function but doesn't handle errors.

If the user enables Redis, it won't successfully set cache because the type of the value cannot be serialized using gob, which is `map[string]interface{}`

So, we registered the types and fixed that.