### PR TITLE
Better way to remove frontend map files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ RUN git clone --recurse-submodules https://github.com/cloudreve/Cloudreve.git
 
 # build frontend
 WORKDIR /cloudreve_builder/Cloudreve/assets
+ENV GENERATE_SOURCEMAP false
+
 RUN yarn install --network-timeout 1000000
-RUN yarn run build && find . -name "*.map" -type f -delete
+RUN yarn run build
 
 # build backend
 WORKDIR /cloudreve_builder/Cloudreve

--- a/build.sh
+++ b/build.sh
@@ -24,13 +24,13 @@ buildAssets() {
   rm -rf assets/build
 
   export CI=false
+  export GENERATE_SOURCEMAP=false
 
   cd $REPO/assets
 
   yarn install
   yarn run build
   cd build
-  find . -name "*.map" -type f -delete
   cd $REPO
   zip -r - assets/build >assets.zip
 }


### PR DESCRIPTION
Create-React-App uses the `GENERATE_SOURCEMAP` variable to control whether to generate map files, the default is `true`.

We can set it to `false` to avoid the generation of map files and the presence of map files in js files, which can avoid many warning events generated by the browser console because the map file cannot be found.