### PR TITLE
Fix: unexpected querying all files when deleting an empty folder

### DIFF
--- a/models/file.go
+++ b/models/file.go
@@ -186,6 +186,10 @@ func RemoveFilesWithSoftLinks(files []File) ([]File, error) {
 	// 结果值
 	filteredFiles := make([]File, 0)
 
+	if len(files) == 0 {
+		return filteredFiles, nil
+	}
+
 	// 查询软链接的文件
 	var filesWithSoftLinks []File
 	tx := DB

--- a/models/file_test.go
+++ b/models/file_test.go
@@ -257,6 +257,19 @@ func TestFile_GetPolicy(t *testing.T) {
 	}
 }
 
+func TestRemoveFilesWithSoftLinks_EmptyArg(t *testing.T) {
+	asserts := assert.New(t)
+	// 传入空
+	{
+		mock.ExpectQuery("SELECT(.+)files(.+)")
+		file, err := RemoveFilesWithSoftLinks([]File{})
+		asserts.Error(mock.ExpectationsWereMet())
+		asserts.NoError(err)
+		asserts.Equal(len(file), 0)
+		DB.Find(&File{})
+	}
+}
+
 func TestRemoveFilesWithSoftLinks(t *testing.T) {
 	asserts := assert.New(t)
 	files := []File{


### PR DESCRIPTION
Fix deleting an empty folder takes a too long time when the size of files is large.

Empty folders have no children, so the parameter of `RemoveFilesWithSoftLinks` is also an empty slice. Then, it builds and executes a query `SELECT * FROM files` with no `WHERE` conditions, which takes the longest time.

![image](https://user-images.githubusercontent.com/45138629/189357028-7f8c767b-dc1d-4282-bf7a-758c1957c39c.png)

