### PR TITLE
Fix: s3(minio) file remove operation hang

### DIFF
--- a/pkg/filesystem/driver/s3/handler.go
+++ b/pkg/filesystem/driver/s3/handler.go
@@ -407,6 +407,7 @@ func (handler *Driver) Meta(ctx context.Context, path string) (*MetaData, error)
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 
 	return &MetaData{
 		Size: uint64(*res.ContentLength),


### PR DESCRIPTION
忘记关闭http body 导致无法删除文件