### PR TITLE
建议 Meta 获取文件信息

### DIFF
--- a/pkg/filesystem/driver/s3/handler.go
+++ b/pkg/filesystem/driver/s3/handler.go
@@ -398,8 +398,8 @@ func (handler *Driver) Token(ctx context.Context, ttl int64, uploadSession *seri
 
 // Meta 获取文件信息
 func (handler *Driver) Meta(ctx context.Context, path string) (*MetaData, error) {
-	res, err := handler.svc.GetObject(
-		&s3.GetObjectInput{
+	res, err := handler.svc.HeadObject(
+		&s3.HeadObjectInput{
 			Bucket: &handler.Policy.BucketName,
 			Key:    &path,
 		})
@@ -407,7 +407,6 @@ func (handler *Driver) Meta(ctx context.Context, path string) (*MetaData, error)
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
 
 	return &MetaData{
 		Size: uint64(*res.ContentLength),


### PR DESCRIPTION
建议更换成更好的 HeadObject 方法因为 HeadObject 方法并不会返回文件 Body 因此不需要 defer res.Body.Close()