### PR TITLE
fix: docker build failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN git clone --recurse-submodules https://github.com/cloudreve/Cloudreve.git
 # build frontend
 WORKDIR /cloudreve_builder/Cloudreve/assets
 ENV GENERATE_SOURCEMAP false
+# Disable new OpenSSL to prevent 0308010C:digital envelope routines::unsupported
+ENV NODE_OPTIONS --openssl-legacy-provider
 
 RUN yarn install --network-timeout 1000000
 RUN yarn run build


### PR DESCRIPTION
webpack v4 使用的 OpenSSL 组件库与高级版本的 NodeJS 使用的新版不兼容，导致使用 Node v16+ 版本构建时会报出  `error:0308010C:digital envelope routines::unsupported` 错误。其中一种解决方案自然是将 NodeJS 版本限定在 16 及以下，但更为推荐的解决方案是暂时使用 `NODE_OPTIONS=--openssl-legacy-provider` 规避，并尝试升级 webpack 相关的组件。

（不过尝试直接升级 webpack 会构建失败，估计是一些依赖版本的问题，没有多尝试，暂时先用旧版支持库应应急吧