### PR TITLE
Build docker image with build.sh file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,11 +32,15 @@ buildAssets() {
   yarn run build
   cd build
   cd $REPO
+
+  # please keep in mind that if this final output binary `assets.zip` name changed, please go and update the `Dockerfile` as well
   zip -r - assets/build >assets.zip
 }
 
 buildBinary() {
   cd $REPO
+
+  # same as assets, if this final output binary `cloudreve` name changed, please go and update the `Dockerfile`
   go build -a -o cloudreve -ldflags " -X 'github.com/cloudreve/Cloudreve/v3/pkg/conf.BackendVersion=$VERSION' -X 'github.com/cloudreve/Cloudreve/v3/pkg/conf.LastCommit=$COMMIT_SHA'"
 }
 


### PR DESCRIPTION
# Context
most time when a change modified the `build.sh` file, it has to change the `Dockerfile` as well, just for keeping one same build step, this is not easy to check if these to files got a gap

# Things in this PR
- [x] modified the `Dockerfile`, now it is using the `build.sh` file for each build steps
- [x] fixed the broken docker build (I think @Candinya just fixed the docker pipeline before this change, thanks for the quick response!)
- [x] bind the toolchain version like for golang, it is using the 1.18 which is currently defined in `go.mod` file and for frontend file using `node.js 16` since using the latest one cannot pass the build

# Result
- the image size should as same as the originanl one
- we can see from the dive info below that there still a lot of space for reduce the image size, maybe this will be fixed later since this is just not an optimization change
## [Dive](https://github.com/wagoodman/dive) info
<img width="1502" alt="image" src="https://user-images.githubusercontent.com/24761186/207653672-238326f9-94b3-4e72-9595-125d2e3cdb92.png">