### PR TITLE
feat(Webdav): Add overwrite support for moveFiles and copyFiles

### DIFF
--- a/pkg/webdav/file.go
+++ b/pkg/webdav/file.go
@@ -38,26 +38,51 @@ func moveFiles(ctx context.Context, fs *filesystem.FileSystem, src FileInfo, dst
 		fileIDs = []uint{src.(*model.File).ID}
 	}
 
-        // 判断是否需要移动
-        if src.GetPosition() != path.Dir(dst) {
-                err = fs.Move(
-                        ctx,
-                        folderIDs,
-                        fileIDs,
-                        src.GetPosition(),
-                        path.Dir(dst),
-                )
-        }
+	// 判断是否需要移动
+	if src.GetPosition() != path.Dir(dst) {
+		err = fs.Move(
+			ctx,
+			folderIDs,
+			fileIDs,
+			src.GetPosition(),
+			path.Dir(dst),
+		)
+	}
+	if overwrite {
+		if err := _checkOverwriteFile(ctx, fs, src, dst); err != nil {
+			return http.StatusNoContent, err
+		}
+	}
 
-        // 判断是否需要重命名
-        if err == nil && src.GetName() != path.Base(dst) {
-                err = fs.Rename(
-                        ctx,
-                        folderIDs,
-                        fileIDs,
-                        path.Base(dst),
-                )
-        }
+	// 判断是否需要移动
+	if src.GetPosition() != path.Dir(dst) {
+		err = fs.Move(
+			ctx,
+			folderIDs,
+			fileIDs,
+			src.GetPosition(),
+			path.Dir(dst),
+		)
+	}
+
+	// 判断是否需要重命名
+	if err == nil && src.GetName() != path.Base(dst) {
+		err = fs.Rename(
+			ctx,
+			folderIDs,
+			fileIDs,
+			path.Base(dst),
+		)
+	}
+	// 判断是否需要重命名
+	if err == nil && src.GetName() != path.Base(dst) {
+		err = fs.Rename(
+			ctx,
+			folderIDs,
+			fileIDs,
+			path.Base(dst),
+		)
+	}
 
 	if err != nil {
 		return http.StatusInternalServerError, err
@@ -73,6 +98,12 @@ func copyFiles(ctx context.Context, fs *filesystem.FileSystem, src FileInfo, dst
 		return http.StatusInternalServerError, errRecursionTooDeep
 	}
 	recursion++
+
+	if overwrite {
+		if err := _checkOverwriteFile(ctx, fs, src, dst); err != nil {
+			return http.StatusNoContent, err
+		}
+	}
 
 	if src.IsDir() {
 		err := fs.Copy(
@@ -92,6 +123,22 @@ func copyFiles(ctx context.Context, fs *filesystem.FileSystem, src FileInfo, dst
 	}
 
 	return http.StatusNoContent, nil
+}
+
+// 判断目标 文件/夹 是否已经存在，存在则先删除目标文件/夹
+func _checkOverwriteFile(ctx context.Context, fs *filesystem.FileSystem, src FileInfo, dst string) error {
+	if src.IsDir() {
+		ok, folder := fs.IsPathExist(dst)
+		if ok {
+			return fs.Delete(ctx, []uint{folder.ID}, []uint{}, false, false)
+		}
+	} else {
+		ok, file := fs.IsFileExist(dst)
+		if ok {
+			return fs.Delete(ctx, []uint{}, []uint{file.ID}, false, false)
+		}
+	}
+	return nil
 }
 
 // walkFS traverses filesystem fs starting at name up to depth levels.

--- a/pkg/webdav/file.go
+++ b/pkg/webdav/file.go
@@ -40,22 +40,11 @@ func moveFiles(ctx context.Context, fs *filesystem.FileSystem, src FileInfo, dst
 
 	// 判断是否需要移动
 	if src.GetPosition() != path.Dir(dst) {
-		err = fs.Move(
-			ctx,
-			folderIDs,
-			fileIDs,
-			src.GetPosition(),
-			path.Dir(dst),
-		)
-	}
-	if overwrite {
-		if err := _checkOverwriteFile(ctx, fs, src, dst); err != nil {
-			return http.StatusNoContent, err
+		if overwrite {
+			if err := _checkOverwriteFile(ctx, fs, src, dst); err != nil {
+				return http.StatusNoContent, err
+			}
 		}
-	}
-
-	// 判断是否需要移动
-	if src.GetPosition() != path.Dir(dst) {
 		err = fs.Move(
 			ctx,
 			folderIDs,
@@ -65,15 +54,6 @@ func moveFiles(ctx context.Context, fs *filesystem.FileSystem, src FileInfo, dst
 		)
 	}
 
-	// 判断是否需要重命名
-	if err == nil && src.GetName() != path.Base(dst) {
-		err = fs.Rename(
-			ctx,
-			folderIDs,
-			fileIDs,
-			path.Base(dst),
-		)
-	}
 	// 判断是否需要重命名
 	if err == nil && src.GetName() != path.Base(dst) {
 		err = fs.Rename(

--- a/pkg/webdav/file.go
+++ b/pkg/webdav/file.go
@@ -38,13 +38,14 @@ func moveFiles(ctx context.Context, fs *filesystem.FileSystem, src FileInfo, dst
 		fileIDs = []uint{src.(*model.File).ID}
 	}
 
+	if overwrite {
+		if err := _checkOverwriteFile(ctx, fs, src, dst); err != nil {
+			return http.StatusInternalServerError, err
+		}
+	}
+
 	// 判断是否需要移动
 	if src.GetPosition() != path.Dir(dst) {
-		if overwrite {
-			if err := _checkOverwriteFile(ctx, fs, src, dst); err != nil {
-				return http.StatusInternalServerError, err
-			}
-		}
 		err = fs.Move(
 			ctx,
 			folderIDs,

--- a/pkg/webdav/file.go
+++ b/pkg/webdav/file.go
@@ -42,7 +42,7 @@ func moveFiles(ctx context.Context, fs *filesystem.FileSystem, src FileInfo, dst
 	if src.GetPosition() != path.Dir(dst) {
 		if overwrite {
 			if err := _checkOverwriteFile(ctx, fs, src, dst); err != nil {
-				return http.StatusNoContent, err
+				return http.StatusInternalServerError, err
 			}
 		}
 		err = fs.Move(
@@ -81,7 +81,7 @@ func copyFiles(ctx context.Context, fs *filesystem.FileSystem, src FileInfo, dst
 
 	if overwrite {
 		if err := _checkOverwriteFile(ctx, fs, src, dst); err != nil {
-			return http.StatusNoContent, err
+			return http.StatusInternalServerError, err
 		}
 	}
 


### PR DESCRIPTION
### 完善 Webdav 的 overwrite 操作，即  overwrite 为 true 时，先删除目标文件再进行后续操作。

我正在使用 [Swift backup](https://play.google.com/store/apps/details?id=org.swiftapps.swiftbackup&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1) 备份手机数据，该软件具有 webdav 支持。

但我在更新备份时，会报告 Server 500 错误，问题发生在 webdav 的 moveFiles 操作。
根据我的分析，确认是 overwrite  未实现带来的文件名冲突问题。
此 PR 目的为修复这个错误。

![Screenshot_2023-03-27-19-48-03-636_org swiftapps](https://user-images.githubusercontent.com/39891083/227973646-c67e1796-1f77-436a-a59f-2e23e6201381.jpg)

![Screenshot_2023-03-27-22-29-57-227_org swiftapps](https://user-images.githubusercontent.com/39891083/227973861-738013bd-71dc-4ea5-b61d-087f89064774.jpg)



