### PR TITLE
index.html 缓存问题

### DIFF
--- a/middleware/frontend.go
+++ b/middleware/frontend.go
@@ -66,7 +66,7 @@ func FrontendFileHandler() gin.HandlerFunc {
 			return
 		}
 
-		if path == "/service-worker.js" {
+		if path == "/service-worker.js" || path == "/index.html" {
 			c.Header("Cache-Control", "public, no-cache")
 		}
 


### PR DESCRIPTION
index.html 不应该被缓存，每次前端资源打包后相关资源是`/static/js/6.c78c6791.chunk.js` 存在哈希值的，index.html 被缓存后，由于index.html 中的引用路径没有发生变化，导致缓存无法及时更新。理想状态下，当前端资源发生变化的时候，在下一次页面刷新应当可以加载最新的资源。