### PR TITLE
为Redis数据库的连接信息添加Username字段

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -173,3 +173,5 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 
 )
+
+replace github.com/gomodule/redigo v2.0.0+incompatible => github.com/gomodule/redigo v1.8.9

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
-github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/gomodule/redigo v1.8.9 h1:Sl3u+2BI/kk+VEatbj0scLdrFhjPmbxOc1myhDP41ws=
+github.com/gomodule/redigo v1.8.9/go.mod h1:7ArFNvsTjH8GMMzB4uy1snslv2BwmginuMs06a1uzZE=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=

--- a/pkg/cache/driver.go
+++ b/pkg/cache/driver.go
@@ -21,6 +21,7 @@ func Init() {
 			10,
 			conf.RedisConfig.Network,
 			conf.RedisConfig.Server,
+			conf.RedisConfig.User,
 			conf.RedisConfig.Password,
 			conf.RedisConfig.DB,
 		)

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -44,7 +44,7 @@ func deserializer(value []byte) (interface{}, error) {
 }
 
 // NewRedisStore 创建新的redis存储
-func NewRedisStore(size int, network, address, password, database string) *RedisStore {
+func NewRedisStore(size int, network, address, user, password, database string) *RedisStore {
 	return &RedisStore{
 		pool: &redis.Pool{
 			MaxIdle:     size,
@@ -63,6 +63,7 @@ func NewRedisStore(size int, network, address, password, database string) *Redis
 					network,
 					address,
 					redis.DialDatabase(db),
+					redis.DialUsername(user),
 					redis.DialPassword(password),
 				)
 				if err != nil {

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -13,7 +13,7 @@ import (
 func TestNewRedisStore(t *testing.T) {
 	asserts := assert.New(t)
 
-	store := NewRedisStore(10, "tcp", "", "", "0")
+	store := NewRedisStore(10, "tcp", "", "", "", "0")
 	asserts.NotNil(store)
 
 	asserts.Panics(func() {

--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -53,6 +53,7 @@ type slave struct {
 type redis struct {
 	Network  string
 	Server   string
+	User	 string
 	Password string
 	DB       string
 }


### PR DESCRIPTION
替换Golang Redis依赖: redigo的版本至当前最新版1.8.9
（v2.0.0被标记为已撤回，且长期未更新）

Redis 6 及以上版本均可把ACL配置为使用username+password认证的状态，
虽然考虑到实际情况大概率也没人折腾redis的ACL就是了（