### PR TITLE
修復 Slave 显示缩略图出现错误

### DIFF
--- a/bootstrap/init.go
+++ b/bootstrap/init.go
@@ -56,6 +56,12 @@ func Init(path string, statics fs.FS) {
 			},
 		},
 		{
+			"slave",
+			func() {
+				model.Init()
+			},
+		},
+		{
 			"master",
 			func() {
 				model.Init()


### PR DESCRIPTION
这个问题应该存在很久了，但一直没人修复。
经排查，发现是 `generateThumbnail` 的 `file.GetPolicy().Type == "local"` 造成
追溯后，确认源头是 `GetPolicyByID` 导致的，具体为 `result := DB.First(&policy, ID)` 的 `DB` 实例没初始化
添加以下语句后发现 API 请求恢复正常。

另外一种修复方式更简单:
在 `pkg/filesystem/image.go#135` 中，
将 `if file.GetPolicy().Type == "local" {` 修改为
`conf.SystemConfig.Mode != "master" || file.GetPolicy().Type == "local"`

Disclaimer: I'm not familer with `Go` and `Cloudreve`. If this fix have a better solution feel free to point out / Open a new PR and mention this PR.