### PR TITLE
docs: add a deploy button to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ chmod +x ./cloudreve
 
 The above is a minimum deploy example, you can refer to [Getting started](https://docs.cloudreve.org/v/en/getting-started/install) for a completed deployment.
 
+### 使用 Sealos 部署
+
+[![](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://cloud.sealos.io/?openapp=system-fastdeploy%3FtemplateName%3Dcloudreve)
+
 ## :gear: Build
 
 You need to have `Go >= 1.18`, `node.js`, `yarn`, `zip`, [goreleaser](https://goreleaser.com/intro/) and other necessary dependencies before you can build it yourself.


### PR DESCRIPTION
Quickly deploy a Cloudreve on Sealos with the click of a button.