### PR TITLE
Fix: doc preview src of local storage policy starts with ":/" (#1842)

### DIFF
--- a/service/explorer/file.go
+++ b/service/explorer/file.go
@@ -230,7 +230,11 @@ func (service *FileIDService) CreateDocPreviewSession(ctx context.Context, c *gi
 	// For newer version of Cloudreve - Local Policy
 	// When do not use a cdn, the downloadURL withouts hosts, like "/api/v3/file/download/xxx"
 	if strings.HasPrefix(downloadURL, "/") {
-		downloadURL = model.GetSiteURL().ResolveReference(downloadURL).String()
+		downloadURI, err := url.Parse(downloadURL)
+		if err != nil {
+			return serializer.Err(serializer.CodeNotSet, err.Error(), err)
+		}
+		downloadURL = model.GetSiteURL().ResolveReference(downloadURI).String()
 	}
 
 	var resp serializer.DocPreviewSession

--- a/service/explorer/file.go
+++ b/service/explorer/file.go
@@ -227,8 +227,10 @@ func (service *FileIDService) CreateDocPreviewSession(ctx context.Context, c *gi
 		return serializer.Err(serializer.CodeNotSet, err.Error(), err)
 	}
 
+	// For newer version of Cloudreve - Local Policy
+	// When do not use a cdn, the downloadURL withouts hosts, like "/api/v3/file/download/xxx"
 	if strings.HasPrefix(downloadURL, "/") {
-		downloadURL = path.Join(model.GetSiteURL().String(), downloadURL)
+		downloadURL = model.GetSiteURL().ResolveReference(downloadURL).String()
 	}
 
 	var resp serializer.DocPreviewSession


### PR DESCRIPTION
Fix: doc preview src of local storage policy starts with ":/" (#1842)