### PR TITLE
feat: Group folder support

### DIFF
--- a/models/file.go
+++ b/models/file.go
@@ -284,7 +284,9 @@ func DeleteFiles(files []*File, uid uint) error {
 			return errors.New("file size is dirty")
 		}
 
-		size += file.Size
+		if file.UserID > 0 {
+			size += file.Size
+		}
 	}
 
 	if uid > 0 {

--- a/models/folder.go
+++ b/models/folder.go
@@ -15,7 +15,7 @@ type Folder struct {
 	gorm.Model
 	Name     string `gorm:"unique_index:idx_only_one_name"`
 	ParentID *uint  `gorm:"index:parent_id;unique_index:idx_only_one_name"`
-	OwnerID  uint   `gorm:"index:owner_id"`
+	OwnerID  int    `gorm:"index:owner_id"`
 
 	// 数据库忽略字段
 	Position      string `gorm:"-"`
@@ -213,8 +213,14 @@ func (folder *Folder) MoveOrCopyFileTo(files []uint, dstFolder *Folder, isCopy b
 // CopyFolderTo 将此目录及其子目录及文件递归复制至dstFolder
 // 返回此操作新增的容量
 func (folder *Folder) CopyFolderTo(folderID uint, dstFolder *Folder) (size uint64, err error) {
+	if folder.OwnerID < 0 {
+		return 0, errors.New("cannot copy group folder")
+	}
+
+	ownerId := uint(folder.OwnerID)
+
 	// 列出所有子目录
-	subFolders, err := GetRecursiveChildFolder([]uint{folderID}, folder.OwnerID, true)
+	subFolders, err := GetRecursiveChildFolder([]uint{folderID}, ownerId, true)
 	if err != nil {
 		return 0, err
 	}

--- a/models/group.go
+++ b/models/group.go
@@ -81,7 +81,7 @@ func (group *Group) AfterSave() (err error) {
 	if group.OptionsSerialized.GroupFolderEnabled {
 		err = group.createGroupFolder(group.OptionsSerialized.GroupFolder)
 	} else {
-		err = group.deleteGroupFolder()
+		err = nil
 	}
 
 	return err
@@ -131,16 +131,16 @@ func (group *Group) createGroupFolder(name string) error {
 }
 
 // deleteGroupFolder 删除用户组文件夹
-func (group *Group) deleteGroupFolder() error {
+func (group *Group) deleteGroupFolder() {
 	tx := DB.Begin()
 	var folder Folder
 	if err := tx.Where("owner_id = ?", -int(group.ID)).First(&folder).Error; err != nil {
-		return err
+		return
 	}
 
 	if err := tx.Delete(&folder).Error; err != nil {
-		return err
+		return
 	}
 
-	return tx.Commit().Error
+	tx.Commit()
 }

--- a/models/group.go
+++ b/models/group.go
@@ -19,6 +19,7 @@ type Group struct {
 	// 数据库忽略字段
 	PolicyList        []uint      `gorm:"-"`
 	OptionsSerialized GroupOption `gorm:"-"`
+	GroupFolder       *Folder     `gorm:"-"`
 }
 
 // GroupOption 用户组其他配置
@@ -81,4 +82,10 @@ func (group *Group) SerializePolicyList() (err error) {
 	optionsValue, err := json.Marshal(&group.OptionsSerialized)
 	group.Options = string(optionsValue)
 	return err
+}
+
+func (group *Group) getGroupFolder() (*Folder, bool) {
+	var folder Folder
+	result := DB.Where("owner_id = ?", -int(group.ID)).First(&folder)
+	return &folder, !result.RecordNotFound()
 }

--- a/models/group.go
+++ b/models/group.go
@@ -81,7 +81,7 @@ func (group *Group) AfterSave() (err error) {
 	if group.OptionsSerialized.GroupFolderEnabled {
 		err = group.createGroupFolder(group.OptionsSerialized.GroupFolder)
 	} else {
-		err = nil
+		group.deleteGroupFolder()
 	}
 
 	return err

--- a/models/share.go
+++ b/models/share.go
@@ -118,7 +118,7 @@ func (share *Share) SourceFolder() *Folder {
 // SourceFile 获取源文件
 func (share *Share) SourceFile() *File {
 	if share.File.ID == 0 {
-		files, _ := GetFilesByIDs([]uint{share.SourceID}, share.UserID)
+		files, _ := GetFilesByIDs([]uint{share.SourceID}, share.UserID, 0)
 		if len(files) > 0 {
 			share.File = files[0]
 		}

--- a/models/source_link.go
+++ b/models/source_link.go
@@ -32,7 +32,7 @@ func (s *SourceLink) Link() (string, error) {
 func GetSourceLinkByID(id interface{}) (*SourceLink, error) {
 	link := &SourceLink{}
 	result := DB.Where("id = ?", id).First(link)
-	files, _ := GetFilesByIDs([]uint{link.FileID}, 0)
+	files, _ := GetFilesByIDs([]uint{link.FileID}, 0, 0)
 	if len(files) > 0 {
 		link.File = files[0]
 	}

--- a/pkg/crontab/collect.go
+++ b/pkg/crontab/collect.go
@@ -60,7 +60,7 @@ func uploadSessionCollect() {
 	placeholders := model.GetUploadPlaceholderFiles(0)
 
 	// 将过期的上传会话按照用户分组
-	userToFiles := make(map[uint][]uint)
+	userToFiles := make(map[int][]uint)
 	for _, file := range placeholders {
 		_, sessionExist := cache.Get(filesystem.UploadSessionCachePrefix + *file.UploadSessionID)
 		if sessionExist {

--- a/pkg/filesystem/archive.go
+++ b/pkg/filesystem/archive.go
@@ -33,7 +33,7 @@ func (fs *FileSystem) Compress(ctx context.Context, writer io.Writer, folderIDs,
 	}
 
 	// 查找待压缩文件
-	files, err := model.GetFilesByIDs(fileIDs, fs.User.ID)
+	files, err := model.GetFilesByIDs(fileIDs, fs.User.ID, fs.User.GroupID)
 	if err != nil && len(fileIDs) != 0 {
 		return ErrDBListObjects
 	}

--- a/pkg/filesystem/file.go
+++ b/pkg/filesystem/file.go
@@ -56,7 +56,7 @@ func (fs *FileSystem) AddFile(ctx context.Context, parent *model.Folder, file fs
 	newFile := model.File{
 		Name:               uploadInfo.FileName,
 		SourceName:         uploadInfo.SavePath,
-		UserID:             fs.User.ID,
+		UserID:             int(fs.User.ID),
 		Size:               uploadInfo.Size,
 		FolderID:           parent.ID,
 		PolicyID:           fs.Policy.ID,

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -262,7 +262,7 @@ func (fs *FileSystem) SetTargetDir(dirs *[]model.Folder) {
 
 // SetTargetFileByIDs 根据文件ID设置目标文件，忽略用户ID
 func (fs *FileSystem) SetTargetFileByIDs(ids []uint) error {
-	files, err := model.GetFilesByIDs(ids, 0)
+	files, err := model.GetFilesByIDs(ids, 0, 0)
 	if err != nil || len(files) == 0 {
 		return ErrFileExisted.WithError(err)
 	}

--- a/pkg/filesystem/manage.go
+++ b/pkg/filesystem/manage.go
@@ -26,7 +26,7 @@ func (fs *FileSystem) Rename(ctx context.Context, dir, file []uint, new string) 
 
 	// 如果源对象是文件
 	if len(file) > 0 {
-		fileObject, err := model.GetFilesByIDs([]uint{file[0]}, fs.User.ID)
+		fileObject, err := model.GetFilesByIDs([]uint{file[0]}, fs.User.ID, fs.User.GroupID)
 		if err != nil || len(fileObject) == 0 {
 			return ErrPathNotExist
 		}
@@ -257,7 +257,7 @@ func (fs *FileSystem) ListDeleteDirs(ctx context.Context, ids []uint) error {
 
 // ListDeleteFiles 根据给定的路径列出要删除的文件
 func (fs *FileSystem) ListDeleteFiles(ctx context.Context, ids []uint) error {
-	files, err := model.GetFilesByIDs(ids, fs.User.ID)
+	files, err := model.GetFilesByIDs(ids, fs.User.ID, fs.User.GroupID)
 	if err != nil {
 		return ErrDBListObjects.WithError(err)
 	}

--- a/pkg/filesystem/path.go
+++ b/pkg/filesystem/path.go
@@ -29,11 +29,11 @@ func (fs *FileSystem) IsPathExist(path string) (bool, *model.Folder) {
 		currentFolder = fs.Root
 	}
 
-	for _, folderName := range pathList {
+	for i, folderName := range pathList {
 		var err error
 
 		// 根目录
-		if folderName == "/" {
+		if i == 0 && folderName == "/" {
 			if currentFolder != nil {
 				continue
 			}
@@ -42,6 +42,13 @@ func (fs *FileSystem) IsPathExist(path string) (bool, *model.Folder) {
 				return false, nil
 			}
 		} else {
+			if i == 1 {
+				groupFolder := fs.User.Group.GroupFolder
+				if groupFolder != nil && folderName == groupFolder.Name {
+					currentFolder = groupFolder
+					continue
+				}
+			}
 			currentFolder, err = currentFolder.GetChild(folderName)
 			if err != nil {
 				return false, nil

--- a/pkg/hashid/hash.go
+++ b/pkg/hashid/hash.go
@@ -56,7 +56,11 @@ func HashDecode(raw string) ([]int, error) {
 
 // HashID 计算数据库内主键对应的HashID
 func HashID(id uint, t int) string {
-	v, _ := HashEncode([]int{int(id), t})
+	return HashIDInt(int(id), t)
+}
+
+func HashIDInt(id int, t int) string {
+	v, _ := HashEncode([]int{id, t})
 	return v
 }
 

--- a/pkg/mocks/wopimock/mock.go
+++ b/pkg/mocks/wopimock/mock.go
@@ -10,7 +10,7 @@ type WopiClientMock struct {
 	mock.Mock
 }
 
-func (w *WopiClientMock) NewSession(user uint, file *model.File, action wopi.ActonType) (*wopi.Session, error) {
+func (w *WopiClientMock) NewSession(user int, file *model.File, action wopi.ActonType) (*wopi.Session, error) {
 	args := w.Called(user, file, action)
 	return args.Get(0).(*wopi.Session), args.Error(1)
 }

--- a/pkg/wopi/types.go
+++ b/pkg/wopi/types.go
@@ -59,7 +59,7 @@ type Session struct {
 type SessionCache struct {
 	AccessToken string
 	FileID      uint
-	UserID      uint
+	UserID      int
 	Action      ActonType
 }
 

--- a/pkg/wopi/wopi.go
+++ b/pkg/wopi/wopi.go
@@ -18,7 +18,7 @@ import (
 
 type Client interface {
 	// NewSession creates a new document session with access token.
-	NewSession(uid uint, file *model.File, action ActonType) (*Session, error)
+	NewSession(uid int, file *model.File, action ActonType) (*Session, error)
 	// AvailableExts returns a list of file extensions that are supported by WOPI.
 	AvailableExts() []string
 }
@@ -116,7 +116,7 @@ func NewClient(endpoint string, cache cache.Driver, http request.Client) (Client
 	}, nil
 }
 
-func (c *client) NewSession(uid uint, file *model.File, action ActonType) (*Session, error) {
+func (c *client) NewSession(uid int, file *model.File, action ActonType) (*Session, error) {
 	if err := c.checkDiscovery(); err != nil {
 		return nil, err
 	}

--- a/service/admin/file.go
+++ b/service/admin/file.go
@@ -87,7 +87,7 @@ func (service *ListFolderService) List(c *gin.Context) serializer.Response {
 
 // Delete 删除文件
 func (service *FileBatchService) Delete(c *gin.Context) serializer.Response {
-	files, err := model.GetFilesByIDs(service.ID, 0)
+	files, err := model.GetFilesByIDs(service.ID, 0, 0)
 	if err != nil {
 		return serializer.DBErr("Failed to list files for deleting", err)
 	}
@@ -141,7 +141,7 @@ func (service *FileBatchService) Delete(c *gin.Context) serializer.Response {
 
 // Get 预览文件
 func (service *FileService) Get(c *gin.Context) serializer.Response {
-	file, err := model.GetFilesByIDs([]uint{service.ID}, 0)
+	file, err := model.GetFilesByIDs([]uint{service.ID}, 0, 0)
 	if err != nil {
 		return serializer.Err(serializer.CodeFileNotFound, "", err)
 	}

--- a/service/admin/file.go
+++ b/service/admin/file.go
@@ -93,7 +93,7 @@ func (service *FileBatchService) Delete(c *gin.Context) serializer.Response {
 	}
 
 	// 根据用户分组
-	userFile := make(map[uint][]model.File)
+	userFile := make(map[int][]model.File)
 	for i := 0; i < len(files); i++ {
 		if _, ok := userFile[files[i].UserID]; !ok {
 			userFile[files[i].UserID] = []model.File{}
@@ -102,7 +102,7 @@ func (service *FileBatchService) Delete(c *gin.Context) serializer.Response {
 	}
 
 	// 异步执行删除
-	go func(files map[uint][]model.File) {
+	go func(files map[int][]model.File) {
 		for uid, file := range files {
 			var (
 				fs  *filesystem.FileSystem
@@ -183,12 +183,12 @@ func (service *AdminListService) Files() serializer.Response {
 	tx.Limit(service.PageSize).Offset((service.Page - 1) * service.PageSize).Find(&res)
 
 	// 查询对应用户
-	users := make(map[uint]model.User)
+	users := make(map[int]model.User)
 	for _, file := range res {
 		users[file.UserID] = model.User{}
 	}
 
-	userIDs := make([]uint, 0, len(users))
+	userIDs := make([]int, 0, len(users))
 	for k := range users {
 		userIDs = append(userIDs, k)
 	}
@@ -197,7 +197,7 @@ func (service *AdminListService) Files() serializer.Response {
 	model.DB.Where("id in (?)", userIDs).Find(&userList)
 
 	for _, v := range userList {
-		users[v.ID] = v
+		users[int(v.ID)] = v
 	}
 
 	return serializer.Response{Data: map[string]interface{}{

--- a/service/callback/upload.go
+++ b/service/callback/upload.go
@@ -120,7 +120,7 @@ func ProcessCallback(service CallbackProcessService, c *gin.Context) serializer.
 	uploadSession := c.MustGet(filesystem.UploadSessionCtx).(*serializer.UploadSession)
 
 	// 查找上传会话创建的占位文件
-	file, err := model.GetFilesByUploadSession(uploadSession.Key, fs.User.ID)
+	file, err := model.GetFilesByUploadSession(uploadSession.Key, fs.User)
 	if err != nil {
 		return serializer.Err(serializer.CodeUploadSessionExpired, "LocalUpload session file placeholder not exist", err)
 	}

--- a/service/explorer/file.go
+++ b/service/explorer/file.go
@@ -433,7 +433,7 @@ func (service *FileIDService) PutContent(ctx context.Context, c *gin.Context) se
 
 	// 取得现有文件
 	fileID, _ := c.Get("object_id")
-	originFile, _ := model.GetFilesByIDs([]uint{fileID.(uint)}, fs.User.ID)
+	originFile, _ := model.GetFilesByIDs([]uint{fileID.(uint)}, fs.User.ID, fs.User.GroupID)
 	if len(originFile) == 0 {
 		return serializer.Err(serializer.CodeFileNotFound, "", nil)
 	}
@@ -485,7 +485,7 @@ func (s *ItemIDService) Sources(ctx context.Context, c *gin.Context) serializer.
 	}
 
 	res := make([]serializer.Sources, 0, len(s.Raw().Items))
-	files, err := model.GetFilesByIDs(s.Raw().Items, fs.User.ID)
+	files, err := model.GetFilesByIDs(s.Raw().Items, fs.User.ID, fs.User.GroupID)
 	if err != nil || len(files) == 0 {
 		return serializer.Err(serializer.CodeFileNotFound, "", err)
 	}

--- a/service/explorer/objects.go
+++ b/service/explorer/objects.go
@@ -381,7 +381,7 @@ func (service *ItemPropertyService) GetProperty(ctx context.Context, c *gin.Cont
 			return serializer.Err(serializer.CodeNotFound, "", err)
 		}
 
-		file, err := model.GetFilesByIDs([]uint{res}, user.ID)
+		file, err := model.GetFilesByIDs([]uint{res}, user.ID, user.GroupID)
 		if err != nil {
 			return serializer.DBErr("Failed to query file records", err)
 		}

--- a/service/explorer/upload.go
+++ b/service/explorer/upload.go
@@ -94,7 +94,7 @@ func (service *UploadService) LocalUpload(ctx context.Context, c *gin.Context) s
 	}
 
 	// 查找上传会话创建的占位文件
-	file, err := model.GetFilesByUploadSession(service.ID, fs.User.ID)
+	file, err := model.GetFilesByUploadSession(service.ID, fs.User)
 	if err != nil {
 		return serializer.Err(serializer.CodeUploadSessionExpired, "", err)
 	}
@@ -232,7 +232,7 @@ func (service *UploadSessionService) Delete(ctx context.Context, c *gin.Context)
 	defer fs.Recycle()
 
 	// 查找需要删除的上传会话的占位文件
-	file, err := model.GetFilesByUploadSession(service.ID, fs.User.ID)
+	file, err := model.GetFilesByUploadSession(service.ID, fs.User)
 	if err != nil {
 		return serializer.Err(serializer.CodeUploadSessionExpired, "", err)
 	}

--- a/service/explorer/wopi.go
+++ b/service/explorer/wopi.go
@@ -94,7 +94,7 @@ func (service *WopiService) FileInfo(c *gin.Context) (*serializer.WopiFileInfo, 
 		ReadOnly:               true,
 		ClosePostMessage:       true,
 		Size:                   int64(fs.FileTarget[0].Size),
-		OwnerId:                hashid.HashID(fs.FileTarget[0].UserID, hashid.UserID),
+		OwnerId:                hashid.HashIDInt(fs.FileTarget[0].UserID, hashid.UserID),
 	}
 
 	if session.Action == wopi.ActionEdit {

--- a/service/share/manage.go
+++ b/service/share/manage.go
@@ -101,7 +101,7 @@ func (service *ShareCreateService) Create(c *gin.Context) serializer.Response {
 			sourceName = folder[0].Name
 		}
 	} else {
-		file, err := model.GetFilesByIDs([]uint{sourceID}, user.ID)
+		file, err := model.GetFilesByIDs([]uint{sourceID}, user.ID, user.GroupID)
 		if err != nil || len(file) == 0 {
 			exist = false
 		} else {


### PR DESCRIPTION
## Support group folder feature.
frontend pr: https://github.com/cloudreve/frontend/pull/168
solved: #1305 #1673 

### Important: key db model modified.
used some little tricks to impl this function and minimize impact meanwhile

models/file.go:
```go
type File struct {
    ...
    UserID int // previous uint
    ...
}
```

models/folder.go:
```go
type Folder struct {
    ...
    OwnerID int // previous uint
    ...
}
```

After this pr, type of `userId` , `ownerId` or any `id` that indicates user owner is `int`. Positive `id` means a `user` owner. Negative `id` means its owner is a `group`


Will upload demo video later. Hope this pr works for those who needed group folder feature before v4 came out : )

