### PR TITLE
Fix: aliyun oss外部导入文件时，误将文件夹当成文件存储

### DIFF
--- a/pkg/filesystem/driver/oss/handler.go
+++ b/pkg/filesystem/driver/oss/handler.go
@@ -172,6 +172,7 @@ func (handler *Driver) List(ctx context.Context, base string, recursive bool) ([
 		if err != nil {
 			continue
 		}
+
 		if strings.HasSuffix(object.Key, "/") {
 			res = append(res, response.Object{
 				Name:         path.Base(object.Key),

--- a/pkg/filesystem/driver/oss/handler.go
+++ b/pkg/filesystem/driver/oss/handler.go
@@ -172,14 +172,24 @@ func (handler *Driver) List(ctx context.Context, base string, recursive bool) ([
 		if err != nil {
 			continue
 		}
-		res = append(res, response.Object{
-			Name:         path.Base(object.Key),
-			Source:       object.Key,
-			RelativePath: filepath.ToSlash(rel),
-			Size:         uint64(object.Size),
-			IsDir:        false,
-			LastModify:   object.LastModified,
-		})
+		if strings.HasSuffix(object.Key, "/") {
+			res = append(res, response.Object{
+				Name:         path.Base(object.Key),
+				RelativePath: filepath.ToSlash(rel),
+				Size:         0,
+				IsDir:        true,
+				LastModify:   time.Now(),
+			})
+		} else {
+			res = append(res, response.Object{
+				Name:         path.Base(object.Key),
+				Source:       object.Key,
+				RelativePath: filepath.ToSlash(rel),
+				Size:         uint64(object.Size),
+				IsDir:        false,
+				LastModify:   object.LastModified,
+			})
+		}
 	}
 
 	return res, nil


### PR DESCRIPTION
在导入 oss 的外部文件时候，打开递归模式，未对返回的文件类型进行区分，误将文件夹当成文件处理，会导致该文件夹下所有文件导入失败，debug 结果如下：
![image](https://github.com/cloudreve/Cloudreve/assets/7615949/6d38863e-08f8-436c-8adb-9ebd70de4c23)

复现步骤
![image](https://github.com/cloudreve/Cloudreve/assets/7615949/f1a13e34-8a3f-42cb-ad31-5c4bf4a2174e)

