### PR TITLE
Fix: Adapt to Gmail.

### DIFF
--- a/pkg/email/smtp.go
+++ b/pkg/email/smtp.go
@@ -1,6 +1,8 @@
 package email
 
 import (
+	"fmt"
+	"github.com/google/uuid"
 	"time"
 
 	"github.com/cloudreve/Cloudreve/v3/pkg/util"
@@ -50,6 +52,7 @@ func (client *SMTP) Send(to, title, body string) error {
 	m.SetAddressHeader("Reply-To", client.Config.ReplyTo, client.Config.Name)
 	m.SetHeader("To", to)
 	m.SetHeader("Subject", title)
+	m.SetHeader("Message-ID", fmt.Sprintf("<%s@%s>", uuid.NewString(), "cloudreve"))
 	m.SetBody("text/html", body)
 	client.ch <- m
 	return nil


### PR DESCRIPTION
Add Message-ID to the mail service header to adapt to services such as Gmail