### PR TITLE
Fixed：External file imports bug that using Amazon S3 storage.

### DIFF
--- a/pkg/filesystem/driver/s3/handler.go
+++ b/pkg/filesystem/driver/s3/handler.go
@@ -147,14 +147,25 @@ func (handler *Driver) List(ctx context.Context, base string, recursive bool) ([
 		if err != nil {
 			continue
 		}
-		res = append(res, response.Object{
-			Name:         path.Base(*object.Key),
-			Source:       *object.Key,
-			RelativePath: filepath.ToSlash(rel),
-			Size:         uint64(*object.Size),
-			IsDir:        false,
-			LastModify:   time.Now(),
-		})
+
+		if strings.HasSuffix(*object.Key, "/") {
+			res = append(res, response.Object{
+				Name:         path.Base(*object.Key),
+				RelativePath: filepath.ToSlash(rel),
+				Size:         0,
+				IsDir:        true,
+				LastModify:   time.Now(),
+			})
+		} else {
+			res = append(res, response.Object{
+				Name:         path.Base(*object.Key),
+				Source:       *object.Key,
+				RelativePath: filepath.ToSlash(rel),
+				Size:         uint64(*object.Size),
+				IsDir:        false,
+				LastModify:   *object.LastModified,
+			})
+		}
 	}
 
 	return res, nil


### PR DESCRIPTION
Fixed a bug where files and file directories were not recursively recognized correctly when using Amazon S3 storage policies for external file imports.