### PR TITLE
fix: add oss callbackSNI support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/go-querystring v1.0.0
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.1
 	github.com/gorilla/websocket v1.4.2
@@ -84,7 +85,6 @@ require (
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/certificate-transparency-go v1.1.2-0.20210511102531-373a877eec92 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect

--- a/pkg/filesystem/driver/oss/handler.go
+++ b/pkg/filesystem/driver/oss/handler.go
@@ -32,10 +32,12 @@ type UploadPolicy struct {
 }
 
 // CallbackPolicy 回调策略
+// https://help.aliyun.com/zh/oss/developer-reference/callback#a8a8e931e392l
 type CallbackPolicy struct {
 	CallbackURL      string `json:"callbackUrl"`
 	CallbackBody     string `json:"callbackBody"`
 	CallbackBodyType string `json:"callbackBodyType"`
+	CallbackSNI      bool `json:"callbackSNI"`
 }
 
 // Driver 阿里云OSS策略适配器
@@ -417,12 +419,14 @@ func (handler *Driver) Token(ctx context.Context, ttl int64, uploadSession *seri
 	siteURL := model.GetSiteURL()
 	apiBaseURI, _ := url.Parse("/api/v3/callback/oss/" + uploadSession.Key)
 	apiURL := siteURL.ResolveReference(apiBaseURI)
+	callbackSNI := apiURL.Scheme == "https"
 
 	// 回调策略
 	callbackPolicy := CallbackPolicy{
 		CallbackURL:      apiURL.String(),
 		CallbackBody:     `{"name":${x:fname},"source_name":${object},"size":${size},"pic_info":"${imageInfo.width},${imageInfo.height}"}`,
 		CallbackBodyType: "application/json",
+		CallbackSNI:      callbackSNI,
 	}
 	callbackPolicyJSON, err := json.Marshal(callbackPolicy)
 	if err != nil {


### PR DESCRIPTION
对于使用阿里云存储策略的，并且同一个IP上部署多个 https 服务的用户，在传回调参数的时候需要打开 `callbackSNI = true` 这个选项。这样反代才能在 tls 握手的时候返回正确的 https cert。

Ref：
https://help.aliyun.com/zh/oss/developer-reference/callback#a8a8e931e392l

已验证过能解决 #1693 #1896 。