### PR TITLE
fix: allow empty password for ShareCreateService

### DIFF
--- a/service/share/manage.go
+++ b/service/share/manage.go
@@ -20,7 +20,7 @@ type (
 	ShareCreateService struct {
 		Uri             string `json:"uri" binding:"required"`
 		IsPrivate       bool   `json:"is_private"`
-		Password        string `json:"password" binding:"max=32,alphanum,omitempty"`
+		Password        string `json:"password" binding:"omitempty,max=32,alphanum"`
 		RemainDownloads int    `json:"downloads"`
 		Expire          int    `json:"expire"`
 		ShareView       bool   `json:"share_view"`


### PR DESCRIPTION
sorry for made a mistake in #2493 ☹️. `omitempty,max=32,alphanum` ***does not equal to*** `max=32,alphanum,omitempty` in `go-playground/validator/v10`. which caused user cannot create public share after #2493 (public share create request does not have `password` in json).