### PR TITLE
feat(captcha): update static asset source option

### DIFF
--- a/inventory/setting.go
+++ b/inventory/setting.go
@@ -395,6 +395,7 @@ var DefaultSettings = map[string]string{
 	"captcha_cap_instance_url":                   "",
 	"captcha_cap_site_key":                       "",
 	"captcha_cap_secret_key":                     "",
+	"captcha_cap_asset_server":                   "cdn",
 	"thumb_width":                                "400",
 	"thumb_height":                               "300",
 	"thumb_entity_suffix":                        "._thumb",

--- a/inventory/setting.go
+++ b/inventory/setting.go
@@ -395,7 +395,7 @@ var DefaultSettings = map[string]string{
 	"captcha_cap_instance_url":                   "",
 	"captcha_cap_site_key":                       "",
 	"captcha_cap_secret_key":                     "",
-	"captcha_cap_asset_server":                   "cdn",
+	"captcha_cap_asset_server":                   "jsdelivr",
 	"thumb_width":                                "400",
 	"thumb_height":                               "300",
 	"thumb_entity_suffix":                        "._thumb",

--- a/pkg/setting/provider.go
+++ b/pkg/setting/provider.go
@@ -671,6 +671,7 @@ func (s *settingProvider) CapCaptcha(ctx context.Context) *Cap {
 		InstanceURL: s.getString(ctx, "captcha_cap_instance_url", ""),
 		SiteKey:     s.getString(ctx, "captcha_cap_site_key", ""),
 		SecretKey:   s.getString(ctx, "captcha_cap_secret_key", ""),
+		AssetServer: s.getString(ctx, "captcha_cap_asset_server", "cdn"),
 	}
 }
 

--- a/pkg/setting/provider.go
+++ b/pkg/setting/provider.go
@@ -671,7 +671,7 @@ func (s *settingProvider) CapCaptcha(ctx context.Context) *Cap {
 		InstanceURL: s.getString(ctx, "captcha_cap_instance_url", ""),
 		SiteKey:     s.getString(ctx, "captcha_cap_site_key", ""),
 		SecretKey:   s.getString(ctx, "captcha_cap_secret_key", ""),
-		AssetServer: s.getString(ctx, "captcha_cap_asset_server", "cdn"),
+		AssetServer: s.getString(ctx, "captcha_cap_asset_server", "jsdelivr"),
 	}
 }
 

--- a/pkg/setting/types.go
+++ b/pkg/setting/types.go
@@ -52,6 +52,7 @@ type Cap struct {
 	InstanceURL string
 	SiteKey     string
 	SecretKey   string
+	AssetServer string
 }
 
 type SMTP struct {

--- a/service/basic/site.go
+++ b/service/basic/site.go
@@ -31,6 +31,7 @@ type SiteConfig struct {
 	TurnstileSiteID  string              `json:"turnstile_site_id,omitempty"`
 	CapInstanceURL   string              `json:"captcha_cap_instance_url,omitempty"`
 	CapSiteKey       string              `json:"captcha_cap_site_key,omitempty"`
+	CapAssetServer   string              `json:"captcha_cap_asset_server,omitempty"`
 	RegisterEnabled  bool                `json:"register_enabled,omitempty"`
 	TosUrl           string              `json:"tos_url,omitempty"`
 	PrivacyPolicyUrl string              `json:"privacy_policy_url,omitempty"`
@@ -138,6 +139,7 @@ func (s *GetSettingService) GetSiteConfig(c *gin.Context) (*SiteConfig, error) {
 		ReCaptchaKey:    reCaptcha.Key,
 		CapInstanceURL:  capCaptcha.InstanceURL,
 		CapSiteKey:      capCaptcha.SiteKey,
+		CapAssetServer:  capCaptcha.AssetServer,
 		AppPromotion:    appSetting.Promotion,
 	}, nil
 }


### PR DESCRIPTION
https://github.com/cloudreve/cloudreve/issues/2584
- Added "Asset Server Source" option for Cap Captcha (jsDelivr, unpkg, or self-hosted).
- Updated admin UI and translations.
- Frontend loads assets based on selected source.
