### PR TITLE
[paln B] fix: new user group error in without replication

### DIFF
--- a/inventory/group.go
+++ b/inventory/group.go
@@ -85,8 +85,8 @@ func (c *groupClient) Upsert(ctx context.Context, group *ent.Group) (*ent.Group,
 			SetPermissions(group.Permissions).
 			SetSettings(group.Settings)
 
-		if group.StoragePolicyID > 0 {
-			stm.SetStoragePolicyID(group.StoragePolicyID)
+		if group.Edges.StoragePolicies != nil && group.Edges.StoragePolicies.ID > 0 {
+			stm.SetStoragePolicyID(group.Edges.StoragePolicies.ID)
 		}
 
 		return stm.Save(ctx)


### PR DESCRIPTION
This is another solution for #2592, [cloudreve/frontend#271](https://github.com/cloudreve/frontend/pull/271)

Unified for logical judgment conditions in create group and update group