### PR TITLE
fix: possile nil pointer caused application crash

### DIFF
--- a/pkg/filemanager/manager/upload.go
+++ b/pkg/filemanager/manager/upload.go
@@ -367,7 +367,9 @@ func (m *manager) updateStateless(ctx context.Context, req *fs.UploadRequest, o 
 		return nil, fmt.Errorf("faield to prepare uplaod: %w", err)
 	}
 
-	req.Props = res.Req.Props
+	if res.Req != nil {
+		req.Props = res.Req.Props
+	}
 	if err := m.Upload(ctx, req, res.Session.Policy); err != nil {
 		if err := o.Node.OnUploadFailed(ctx, &fs.StatelessOnUploadFailedService{
 			UploadSession: res.Session,


### PR DESCRIPTION
## 问题描述

使用离线下载功能出现以下情况（日志模式为 debug ）：

```log
[Info]   2025-08-06 19:15:17 [/home/vsts/work/1/s/pkg/downloader/aria2/aria2.go:67] [Cid: fd97f0d5-4b36-47d0-aed3-be6a339cfcc1] Creating aria2 task with url "https://candinya.com/posts/build-an-all-flash-nas-for-home-datacenter/storage-family-portrait.webp" saving to "/cloudreve/data/temp/aria2/78a52811-c920-4325-bd64-e183cbc2884a"...
[Info]   2025-08-06 19:15:17 [/home/vsts/work/1/s/pkg/logging/logger.go:193] [Cid: fd97f0d5-4b36-47d0-aed3-be6a339cfcc1] [Incoming]  200 |    1.615441ms |    192.99.21.60 | POST     "/api/v4/slave/download/task"
[Info]   2025-08-06 19:15:27 [/home/vsts/work/1/s/pkg/logging/logger.go:193] [Cid: fd97f0d5-4b36-47d0-aed3-be6a339cfcc1] [Incoming]  200 |     895.726µs |    192.99.21.60 | POST     "/api/v4/slave/download/status"
[Info]   2025-08-06 19:15:37 [/home/vsts/work/1/s/pkg/queue/queue.go:360] [Cid: fd97f0d5-4b36-47d0-aed3-be6a339cfcc1] Task 1 status changed from "" to "queued".
[Info]   2025-08-06 19:15:37 [/home/vsts/work/1/s/pkg/queue/queue.go:202] New Task with type "" submitted to queue "SlaveQueue" by ""
[Info]   2025-08-06 19:15:37 [/home/vsts/work/1/s/pkg/logging/logger.go:193] [Cid: fd97f0d5-4b36-47d0-aed3-be6a339cfcc1] [Incoming]  200 |     151.109µs |    192.99.21.60 | PUT      "/api/v4/slave/task"
[Info]   2025-08-06 19:15:37 [/home/vsts/work/1/s/pkg/queue/queue.go:360] [Cid: fd97f0d5-4b36-47d0-aed3-be6a339cfcc1 TaskID: 1 Queue: SlaveQueue] Task 1 status changed from "queued" to "processing".
[Debug]  2025-08-06 19:15:37 [/home/vsts/work/1/s/pkg/queue/queue.go:291] [Cid: fd97f0d5-4b36-47d0-aed3-be6a339cfcc1 TaskID: 1 Queue: SlaveQueue] Iteration started.
[Info]   2025-08-06 19:15:37 [/home/vsts/work/1/s/pkg/filemanager/workflows/upload.go:118] [Cid: fd97f0d5-4b36-47d0-aed3-be6a339cfcc1 TaskID: 1 Queue: SlaveQueue] Uploading file /cloudreve/data/temp/aria2/78a52811-c920-4325-bd64-e183cbc2884a/storage-family-portrait.webp to cloudreve://my/Downloads/storage-family-portrait.webp...
[Info]   2025-08-06 19:15:38 [/home/vsts/work/1/s/pkg/logging/logger.go:193] [Cid: fd97f0d5-4b36-47d0-aed3-be6a339cfcc1 TaskID: 1 Queue: SlaveQueue] [Outgoing]  200 |  627.181417ms |       localhost | PUT      "https://<SERVER_DOMAIN>/api/v4/slave/statelessUpload/prepare"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x192a9b2]

goroutine 31 [running]:
github.com/cloudreve/Cloudreve/v4/pkg/filemanager/manager.(*manager).updateStateless(0xc0009d32c0, {0x307cc10, 0xc00067adb0}, 0xc00098b4f0, 0xc0008d2700)
        /home/vsts/work/1/s/pkg/filemanager/manager/upload.go:370 +0x112
github.com/cloudreve/Cloudreve/v4/pkg/filemanager/manager.(*manager).Update(0xc0009d32c0, {0x307cc10, 0xc00067adb0}, 0xc00098b4f0, {0xc00067b620, 0x3, 0x50d6df?})
        /home/vsts/work/1/s/pkg/filemanager/manager/upload.go:306 +0x3e5
github.com/cloudreve/Cloudreve/v4/pkg/filemanager/workflows.(*SlaveUploadTask).Do.func1(0x0, 0x0, {0xc000968c50, {0xc0004e6300, 0x5c}, 0x21424, 0x1})
        /home/vsts/work/1/s/pkg/filemanager/workflows/upload.go:165 +0xb5f
created by github.com/cloudreve/Cloudreve/v4/pkg/filemanager/workflows.(*SlaveUploadTask).Do in goroutine 30
        /home/vsts/work/1/s/pkg/filemanager/workflows/upload.go:198 +0xace
exited with code 2
```

其中出现了 nil pointer 问题导致程序 panic 重启，因此在后续的主机查询任务状态时会出现失败的情况。已知可能的错误表现（在主机的 `离线下载` 页面中检查任务）为 `failed to get slave task: task not found:` ，若从机未及时启动则会是 `failed to get slave task: Remote returns unexpected status code: 502` 。

## 解决思路

根据打印的日志检查，怀疑是当 `res.Req` 为 nil 时会触发这个 panic 。但我没有执行测试确认这个 PR 是否能修复这个问题（没有现成的 CI 参考所以就没折磨自己和流水线打架）

## 补充信息

我的部署模式为 1 主机(pro版) + 2 从机(开源版)，其中 A 从机负责存储， B 从机负责离线下载，主机只负责管理用户和数据结构，不确定是否是因为这种比较冷门的部署模式导致出现的边界情况。

（懒得翻译成英文了，就这样吧）