### PR TITLE
fix: Some containers won't auto restart in the current Docker Compose (#2931)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     depends_on:
       - postgresql
       - redis
-    restart: always
+    restart: unless-stopped
     ports:
       - 5212:5212
       - 6888:6888
@@ -26,6 +26,7 @@ services:
     # backup & consult https://www.postgresql.org/docs/current/pgupgrade.html 
     image: postgres:17    
     container_name: postgresql
+    restart: unless-stopped
     environment:
       - POSTGRES_USER=cloudreve
       - POSTGRES_DB=cloudreve
@@ -36,6 +37,7 @@ services:
   redis:
     image: redis:latest
     container_name: redis
+    restart: unless-stopped
     volumes:
       - redis_data:/data
 


### PR DESCRIPTION
Add "restart: unless-stopped" to the database and redis container.

#2931