### PR TITLE
fix(ks3): fix content disposition format for download filename (#3040)

### DIFF
--- a/pkg/filemanager/driver/ks3/ks3.go
+++ b/pkg/filemanager/driver/ks3/ks3.go
@@ -347,7 +347,7 @@ func (handler *Driver) Source(ctx context.Context, e fs.Entity, args *driver.Get
 	var contentDescription *string
 	if args.IsDownload {
 		encodedFilename := url.PathEscape(args.DisplayName)
-		contentDescription = aws.String(fmt.Sprintf(`attachment; filename="%s"`, encodedFilename))
+		contentDescription = aws.String(fmt.Sprintf(`attachment; filename=%s`, encodedFilename))
 	}
 
 	// 确保过期时间不小于 0 ，如果小于则设置为 7 天


### PR DESCRIPTION
Remove `"` in ResponseContentDisposition.

For manually test use:
`https://ks3-resources.ks3-cn-beijing.ksyuncs.com/kssyun.png?response-content-disposition=attachment; filename="1.jpg"`

`https://ks3-resources.ks3-cn-beijing.ksyuncs.com/kssyun.png?response-content-disposition=attachment; filename=1.jpg`

<img width="100" height="154" src="https://github.com/user-attachments/assets/1290e73d-a26d-4bf7-bf9f-7c4d7c456d04" />