### PR TITLE
fix(deps): bump github.com/wneessen/go-mail from 0.7.1 to 0.7.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.54
 	github.com/ua-parser/uap-go v0.0.0-20250213224047-9c035f085b90
 	github.com/upyun/go-sdk v2.1.0+incompatible
-	github.com/wneessen/go-mail v0.7.1
+	github.com/wneessen/go-mail v0.7.2
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
 	golang.org/x/image v0.18.0
 	golang.org/x/text v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -981,6 +981,8 @@ github.com/weppos/publicsuffix-go v0.13.1-0.20210123135404-5fd73613514e/go.mod h
 github.com/weppos/publicsuffix-go v0.15.1-0.20210511084619-b1f36a2d6c0b/go.mod h1:HYux0V0Zi04bHNwOHy4cXJVz/TQjYonnF6aoYhj+3QE=
 github.com/wneessen/go-mail v0.7.1 h1:rvy63sp14N06/kdGqCYwW8Na5gDCXjTQM1E7So4PuKk=
 github.com/wneessen/go-mail v0.7.1/go.mod h1:+TkW6QP3EVkgTEqHtVmnAE/1MRhmzb8Y9/W3pweuS+k=
+github.com/wneessen/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=
+github.com/wneessen/go-mail v0.7.2/go.mod h1:+TkW6QP3EVkgTEqHtVmnAE/1MRhmzb8Y9/W3pweuS+k=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/go-gitlab v0.31.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=


### PR DESCRIPTION
## Summary

Upgrade `go-mail` from v0.7.1 to v0.7.2 to fix a regression that strips the display name from the `From` header.

## Problem

When sending emails via Tencent Cloud SES, the following error occurs:

```
内部错误 (Failed to send test email: send failed: closing SMTP DATA writer:
554 5.0.0 Error: transaction failed. Detailed error:
##SES-response-json:{"Response":{"RequestId":"5abbd1c2-8092-401d-9980-7c8988a9b42e",
"QcloudError":{"Error":{"Code":"FailedOperation.NotAuthenticatedSender",
"Message":"操作失败。发件sender没有经过认证，无法发送。"}}}}
```

Tencent Cloud SES requires the `From` header to include a display name (e.g. `"WittF-Mail" <noreply@wit.tf>`). A bare address like `<noreply@wit.tf>` is rejected.

## Root Cause

go-mail v0.7.1 introduced a regression ([wneessen/go-mail#497](https://github.com/wneessen/go-mail/issues/497)): `GetSender(false)` mutates the original `*mail.Address` pointer by setting `addr.Name = ""`, which strips the display name from the `From` header before the message body is written over SMTP.

This was fixed in v0.7.2 ([wneessen/go-mail#498](https://github.com/wneessen/go-mail/pull/498)) by using a value copy instead of a pointer copy.

## Changes

- `go.mod` — bump `github.com/wneessen/go-mail` v0.7.1 → v0.7.2
- `go.sum` — updated checksums