### PR TITLE
feat: allow calculate root folder summary (adapt for https://github.com/cloudreve/frontend/pull/333)

### DIFF
--- a/pkg/filemanager/fs/dbfs/dbfs.go
+++ b/pkg/filemanager/fs/dbfs/dbfs.go
@@ -455,13 +455,20 @@ func (f *DBFS) Get(ctx context.Context, path *fs.URI, opts ...fs.Option) (fs.Fil
 			return nil, fs.ErrOwnerOnly
 		}
 
-		// first, try to load from cache
-		summary, ok := f.cache.Get(fmt.Sprintf("%s%d", folderSummaryCachePrefix, target.ID()))
-		if ok {
-			summaryTyped := summary.(fs.FolderSummary)
-			target.FileFolderSummary = &summaryTyped
-		} else {
-			// cache miss, walk the folder to get the summary
+		loadFolderSummaryDone := false
+
+		// first, try to load from cache if cache is not bypassed
+		if !o.bypassFolderSummaryCache {
+			summary, ok := f.cache.Get(fmt.Sprintf("%s%d", folderSummaryCachePrefix, target.ID()))
+			if ok {
+				summaryTyped := summary.(fs.FolderSummary)
+				target.FileFolderSummary = &summaryTyped
+				loadFolderSummaryDone = true
+			}
+		}
+
+		if !loadFolderSummaryDone {
+			// cache miss or bypass, walk the folder to get the summary
 			newSummary := &fs.FolderSummary{Completed: true}
 			if f.user.Edges.Group == nil {
 				return nil, fmt.Errorf("user group not loaded")

--- a/pkg/filemanager/fs/dbfs/options.go
+++ b/pkg/filemanager/fs/dbfs/options.go
@@ -9,6 +9,7 @@ import (
 type dbfsOption struct {
 	*fs.FsOption
 	loadFolderSummary          bool
+	bypassFolderSummaryCache   bool
 	extendedInfo               bool
 	loadFilePublicMetadata     bool
 	loadFileShareIfOwned       bool
@@ -170,6 +171,14 @@ func WithExtendedInfo() fs.Option {
 func WithLoadFolderSummary() fs.Option {
 	return optionFunc(func(o *dbfsOption) {
 		o.loadFolderSummary = true
+	})
+}
+
+// WithBypassFolderSummaryCache enables bypassing existing cached folder summary.
+// Newly calculated summary will still be written to cache.
+func WithBypassFolderSummaryCache() fs.Option {
+	return optionFunc(func(o *dbfsOption) {
+		o.bypassFolderSummaryCache = true
 	})
 }
 

--- a/service/explorer/file.go
+++ b/service/explorer/file.go
@@ -640,7 +640,7 @@ func (s *GetFileInfoService) Get(c *gin.Context) (*FileResponse, error) {
 		return nil, serializer.NewError(serializer.CodeParamErr, "unknown uri", err)
 	}
 
-	opts := []fs.Option{dbfs.WithFilePublicMetadata(), dbfs.WithNotRoot()}
+	opts := []fs.Option{dbfs.WithFilePublicMetadata()}
 	if s.ExtendedInfo {
 		opts = append(opts, dbfs.WithExtendedInfo(), dbfs.WithEntityUser(), dbfs.WithFileShareIfOwned())
 	}

--- a/service/explorer/file.go
+++ b/service/explorer/file.go
@@ -603,10 +603,11 @@ func (s *UnlockFileService) Unlock(c *gin.Context) error {
 type (
 	GetFileInfoParameterCtx struct{}
 	GetFileInfoService      struct {
-		Uri           string `form:"uri"`
-		ID            string `form:"id"`
-		ExtendedInfo  bool   `form:"extended"`
-		FolderSummary bool   `form:"folder_summary"`
+		Uri                      string `form:"uri"`
+		ID                       string `form:"id"`
+		ExtendedInfo             bool   `form:"extended"`
+		FolderSummary            bool   `form:"folder_summary"`
+		FolderSummaryBypassCache bool   `form:"nocache"`
 	}
 )
 
@@ -645,6 +646,9 @@ func (s *GetFileInfoService) Get(c *gin.Context) (*FileResponse, error) {
 	}
 	if s.FolderSummary {
 		opts = append(opts, dbfs.WithLoadFolderSummary())
+		if s.FolderSummaryBypassCache {
+			opts = append(opts, dbfs.WithBypassFolderSummaryCache())
+		}
 	}
 
 	file, err := m.Get(c, uri, opts...)


### PR DESCRIPTION
**Hint:** add param `nocache=true` to bypass cache.