### PR TITLE
fix: created_at ordering for file listings

### DIFF
--- a/inventory/file_utils.go
+++ b/inventory/file_utils.go
@@ -383,6 +383,8 @@ func getFileOrderOption(args *ListFileParameters) []file.OrderOption {
 		return []file.OrderOption{file.ByName(orderTerm), file.ByID(orderTerm)}
 	case file.FieldSize:
 		return []file.OrderOption{file.BySize(orderTerm), file.ByID(orderTerm)}
+	case file.FieldCreatedAt:
+		return []file.OrderOption{file.ByCreatedAt(orderTerm), file.ByID(orderTerm)}
 	case file.FieldUpdatedAt:
 		return []file.OrderOption{file.ByUpdatedAt(orderTerm), file.ByID(orderTerm)}
 	default:
@@ -435,10 +437,16 @@ var fileCursorQuery = map[string]map[bool]func(token *PageToken) predicate.File{
 	},
 	file.FieldCreatedAt: {
 		true: func(token *PageToken) predicate.File {
-			return file.IDLT(token.ID)
+			return file.Or(
+				file.CreatedAtLT(*token.Time),
+				file.And(file.CreatedAt(*token.Time), file.IDLT(token.ID)),
+			)
 		},
 		false: func(token *PageToken) predicate.File {
-			return file.IDGT(token.ID)
+			return file.Or(
+				file.CreatedAtGT(*token.Time),
+				file.And(file.CreatedAt(*token.Time), file.IDGT(token.ID)),
+			)
 		},
 	},
 	file.FieldUpdatedAt: {
@@ -502,6 +510,8 @@ func getFileNextPageToken(hasher hashid.Encoder, last *ent.File, args *ListFileP
 	switch args.OrderBy {
 	case file.FieldName:
 		token.String = last.Name
+	case file.FieldCreatedAt:
+		token.Time = &last.CreatedAt
 	case file.FieldSize:
 		token.Int = int(last.Size)
 	case file.FieldUpdatedAt:


### PR DESCRIPTION
## Summary

This PR fixes file listing order when `order_by=created_at` is requested.

<img width="591" height="778" alt="image" src="https://github.com/user-attachments/assets/504b10ad-cf91-4632-8406-19f1f3f9a913" />


Previously, `created_at` was not mapped to the actual file order options, so both offset and cursor pagination could fall back to ID ordering instead of sorting by `created_at`. This change adds proper `created_at` sorting, fixes the cursor predicate for `created_at`, and includes `created_at` in the next-page token so pagination remains stable across pages.

## Testing

- Added regression tests for `created_at` sorting in offset pagination
- Added regression tests for `created_at` cursor pagination
- Verified API behavior with Docker-based read/write testing

## Affected APIs

This change affects the file listing API:

- `GET /api/v4/file`

The fix applies when using query parameters such as:

- `uri`
- `page`
- `page_size`
- `order_by=created_at`
- `order_direction=asc|desc`
- `next_page_token`

In particular, it fixes:

- incorrect fallback to ID ordering when `order_by=created_at` is requested
- unstable cursor pagination for `created_at` sorting across pages