### PR TITLE
filemanager/manager: surface incomplete prepare-upload response instead of nil-deref

### DIFF
--- a/pkg/filemanager/manager/upload.go
+++ b/pkg/filemanager/manager/upload.go
@@ -406,6 +406,12 @@ func (m *manager) updateStateless(ctx context.Context, req *fs.UploadRequest, o 
 	if err != nil {
 		return nil, fmt.Errorf("faield to prepare uplaod: %w", err)
 	}
+	// A successful upstream call may still return a response with nil Req or
+	// Session — observed when the master returned 502 mid-prepare (#3441) and
+	// crashed the slave on the next attribute access.
+	if res == nil || res.Req == nil || res.Session == nil {
+		return nil, fmt.Errorf("stateless prepare upload returned an incomplete response")
+	}
 
 	req.Props = res.Req.Props
 	if err := m.Upload(ctx, req, res.Session.Policy, res.Session); err != nil {

--- a/pkg/filemanager/manager/upload.go
+++ b/pkg/filemanager/manager/upload.go
@@ -407,7 +407,7 @@ func (m *manager) updateStateless(ctx context.Context, req *fs.UploadRequest, o 
 		return nil, fmt.Errorf("faield to prepare uplaod: %w", err)
 	}
 	// A successful upstream call may still return a response with nil Req or
-	// Session — observed when the master returned 502 mid-prepare (#3441) and
+	// Session, observed when the master returned 502 mid-prepare (#3441) and
 	// crashed the slave on the next attribute access.
 	if res == nil || res.Req == nil || res.Session == nil {
 		return nil, fmt.Errorf("stateless prepare upload returned an incomplete response")


### PR DESCRIPTION
Fixes #3441.

`updateStateless` accessed `res.Req.Props` and `res.Session.Policy` immediately after a successful `Node.PrepareUpload` call. The user's repro shows the master returning 502 mid-prepare while the slave still got back a response with `err == nil` but partially-populated fields, segfaulting at upload.go:410 on every offline transfer afterwards. Validate the response shape and return a clear error so the slave queue can retry instead of crashing.