### PR TITLE
fix: validate upload callback secret

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"crypto/subtle"
 	"net/http"
 
 	"github.com/cloudreve/Cloudreve/v4/application/dependency"
@@ -204,6 +205,13 @@ func uploadCallbackCheck(c *gin.Context, policyType types.PolicyType) error {
 	}
 
 	callbackSession := callbackSessionRaw.(fs.UploadSession)
+	if subtle.ConstantTimeCompare(
+		[]byte(callbackSession.CallbackSecret),
+		[]byte(c.Param("key")),
+	) != 1 {
+		return serializer.NewError(serializer.CodeCredentialInvalid, "Invalid callback secret", nil)
+	}
+
 	c.Set(manager.UploadSessionCtx, &callbackSession)
 	if callbackSession.Policy.Type != string(policyType) {
 		return serializer.NewError(serializer.CodePolicyNotAllowed, "", nil)


### PR DESCRIPTION
## Summary

Validate the callback secret in upload callback URLs against the secret stored in the upload session.

Previously, callback validation only checked the session ID and storage policy type. The `:key` route parameter was generated and included in callback URLs but never validated, allowing any key to be used with a valid upload session ID.

## Changes

 - Compare the callback `:key` with `UploadSession.CallbackSecret`
 - Use constant-time comparison to avoid timing-based secret disclosure
 - Return `CodeCredentialInvalid` when the secret does not match