### PR TITLE
fix(upload): set concurrent chunk upload to 1 when disk pre-allocation is disabled

### DIFF
--- a/pkg/filemanager/driver/local/local.go
+++ b/pkg/filemanager/driver/local/local.go
@@ -226,6 +226,10 @@ func (handler *Driver) Token(ctx context.Context, uploadSession *fs.UploadSessio
 		if err := Fallocate(f, 0, uploadSession.Props.Size); err != nil {
 			handler.l.Warning("Failed to preallocate file: %s", err)
 		}
+	} else {
+		// When disk pre-allocation is disabled, concurrent chunk uploads must be 1
+		// to avoid disk fragmentation and write contention on local storage.
+		handler.Policy.Settings.ChunkConcurrency = 1
 	}
 
 	return &fs.UploadCredential{

--- a/pkg/filemanager/driver/local/local.go
+++ b/pkg/filemanager/driver/local/local.go
@@ -229,7 +229,9 @@ func (handler *Driver) Token(ctx context.Context, uploadSession *fs.UploadSessio
 	} else {
 		// When disk pre-allocation is disabled, concurrent chunk uploads must be 1
 		// to avoid disk fragmentation and write contention on local storage.
-		handler.Policy.Settings.ChunkConcurrency = 1
+ 		settings := *handler.Policy.Settings
+ 		settings.ChunkConcurrency = 1
+ 		handler.Policy.Settings = &settings
 	}
 
 	return &fs.UploadCredential{

--- a/pkg/filemanager/driver/remote/remote.go
+++ b/pkg/filemanager/driver/remote/remote.go
@@ -153,7 +153,9 @@ func (handler *Driver) Token(ctx context.Context, uploadSession *fs.UploadSessio
 	// When disk pre-allocation is disabled, concurrent chunk uploads must be 1
 	// to avoid disk fragmentation and write contention on slave storage.
 	if !handler.Policy.Settings.PreAllocate {
-		handler.Policy.Settings.ChunkConcurrency = 1
+		settings := *handler.Policy.Settings
+		settings.ChunkConcurrency = 1
+		handler.Policy.Settings = &settings
 	}
 
 	return &fs.UploadCredential{

--- a/pkg/filemanager/driver/remote/remote.go
+++ b/pkg/filemanager/driver/remote/remote.go
@@ -150,6 +150,12 @@ func (handler *Driver) Token(ctx context.Context, uploadSession *fs.UploadSessio
 		return nil, fmt.Errorf("failed to sign upload url: %w", err)
 	}
 
+	// When disk pre-allocation is disabled, concurrent chunk uploads must be 1
+	// to avoid disk fragmentation and write contention on slave storage.
+	if !handler.Policy.Settings.PreAllocate {
+		handler.Policy.Settings.ChunkConcurrency = 1
+	}
+
 	return &fs.UploadCredential{
 		SessionID:  uploadSession.Props.UploadSessionID,
 		ChunkSize:  handler.Policy.Settings.ChunkSize,


### PR DESCRIPTION
Currently a storage policy's previously configured chunk concurrency value would still be returned after pre-allocate was turned off, allowing concurrent chunk writes that cause disk fragmentation on local/slave storage.

When disk pre-allocation is disabled, concurrent chunk uploads must be 1 to avoid disk fragmentation and write contention on local/slave storage.